### PR TITLE
feat: モノトーンスタイルプリセットと標準/モノトーン切替 UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,6 +53,33 @@
         opacity: 0.5;
         cursor: wait;
       }
+      .preset-group {
+        display: inline-flex;
+        border: 1px solid #888;
+        border-radius: 4px;
+        overflow: hidden;
+      }
+      .preset-group button {
+        appearance: none;
+        border: 0;
+        background: #fff;
+        padding: 6px 10px;
+        font-size: 13px;
+        cursor: pointer;
+      }
+      .preset-group button + button {
+        border-left: 1px solid #ccc;
+      }
+      .preset-group button:hover {
+        background: #f3f3f3;
+      }
+      .preset-group button[aria-pressed="true"] {
+        background: #333;
+        color: #fff;
+      }
+      .preset-group button[aria-pressed="true"]:hover {
+        background: #222;
+      }
       #map {
         width: 100%;
         height: 100%;
@@ -64,6 +91,10 @@
       <header>
         <h1>map-simplifier</h1>
         <span class="spacer"></span>
+        <div class="preset-group" role="group" aria-label="スタイルプリセット">
+          <button id="preset-standard" type="button" aria-pressed="true">標準</button>
+          <button id="preset-mono" type="button" aria-pressed="false">モノトーン</button>
+        </div>
         <button id="export-png" class="primary" type="button">PNG書き出し</button>
       </header>
       <div id="map"></div>

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 import maplibregl, { type Map as MapLibreMap } from "maplibre-gl";
 import "maplibre-gl/dist/maplibre-gl.css";
-import { buildBaseStyle } from "./map/style";
+import { buildBaseStyle, type Preset } from "./map/style";
 import { GSI_ATTRIBUTION } from "./map/gsiSource";
 import {
   DEFAULT_VIEW,
@@ -10,20 +10,23 @@ import {
 } from "./state/viewState";
 import { buildExportFilename, composePngWithCredit, downloadCanvasAsPng } from "./export/png";
 
-const mapRoot = document.getElementById("map");
-const exportButton = document.getElementById("export-png");
-if (!mapRoot || !(mapRoot instanceof HTMLElement)) {
-  throw new Error("missing #map container");
-}
-if (!(exportButton instanceof HTMLButtonElement)) {
-  throw new Error("missing #export-png button");
+function requireEl<T extends Element>(id: string, ctor: new (...a: never[]) => T): T {
+  const el = document.getElementById(id);
+  if (!(el instanceof ctor)) throw new Error(`missing #${id}`);
+  return el;
 }
 
+const mapRoot = requireEl("map", HTMLElement);
+const exportButton = requireEl("export-png", HTMLButtonElement);
+const presetStandardBtn = requireEl("preset-standard", HTMLButtonElement);
+const presetMonoBtn = requireEl("preset-mono", HTMLButtonElement);
+
 const initialView: ViewState = decodeHashToView(window.location.hash) ?? DEFAULT_VIEW;
+let currentPreset: Preset = "standard";
 
 const map: MapLibreMap = new maplibregl.Map({
   container: mapRoot,
-  style: buildBaseStyle(),
+  style: buildBaseStyle(currentPreset),
   center: [initialView.center.lng, initialView.center.lat],
   zoom: initialView.zoom,
   hash: false,
@@ -59,6 +62,17 @@ map.on("load", () => {
 if (import.meta.env.DEV) {
   (globalThis as unknown as { __mlMap?: MapLibreMap }).__mlMap = map;
 }
+
+function applyPreset(next: Preset): void {
+  if (next === currentPreset) return;
+  currentPreset = next;
+  // source と layer を差分更新で入れ替える。diff: true なら source(タイル)は再取得しない。
+  map.setStyle(buildBaseStyle(next), { diff: true });
+  presetStandardBtn.setAttribute("aria-pressed", String(next === "standard"));
+  presetMonoBtn.setAttribute("aria-pressed", String(next === "mono"));
+}
+presetStandardBtn.addEventListener("click", () => applyPreset("standard"));
+presetMonoBtn.addEventListener("click", () => applyPreset("mono"));
 
 exportButton.addEventListener("click", async () => {
   exportButton.disabled = true;

--- a/src/map/style.ts
+++ b/src/map/style.ts
@@ -18,10 +18,53 @@ const SOURCE_ID = "gsi";
 //   symbol     : Point      記号
 //   label      : Point      注記
 
-export function buildBaseStyle(): StyleSpecification {
+export const PRESETS = ["standard", "mono"] as const;
+export type Preset = (typeof PRESETS)[number];
+
+interface PresetPalette {
+  bg: string;
+  waterarea: string;
+  wstructurea: string;
+  river: string;
+  railway: string;
+  road: string;
+  buildingFill: string;
+  buildingOutline: string;
+  boundary: string;
+}
+
+const PALETTES: Record<Preset, PresetPalette> = {
+  standard: {
+    bg: "#fafafa",
+    waterarea: "#d6e4ec",
+    wstructurea: "#c8d7e0",
+    river: "#88a7b8",
+    railway: "#666666",
+    road: "#bfbfbf",
+    buildingFill: "#d8d3ca",
+    buildingOutline: "#b5ae9f",
+    boundary: "#9a9a9a",
+  },
+  // グレースケール簡略化。紙面（単色印刷）への馴染みを優先。
+  // 鉄道を最も濃く、道路はやや薄く、水域は陰影で差をつける。
+  mono: {
+    bg: "#ffffff",
+    waterarea: "#d6d6d6",
+    wstructurea: "#c8c8c8",
+    river: "#8a8a8a",
+    railway: "#2a2a2a",
+    road: "#6a6a6a",
+    buildingFill: "#ebebeb",
+    buildingOutline: "#b8b8b8",
+    boundary: "#8a8a8a",
+  },
+};
+
+export function buildBaseStyle(preset: Preset = "standard"): StyleSpecification {
+  const c = PALETTES[preset];
   return {
     version: 8,
-    name: "map-simplifier-base",
+    name: `map-simplifier-${preset}`,
     sources: {
       [SOURCE_ID]: buildGsiVectorSource(),
     },
@@ -29,35 +72,35 @@ export function buildBaseStyle(): StyleSpecification {
       {
         id: "bg",
         type: "background",
-        paint: { "background-color": "#fafafa" },
+        paint: { "background-color": c.bg },
       },
       {
         id: "waterarea-fill",
         type: "fill",
         source: SOURCE_ID,
         "source-layer": "waterarea",
-        paint: { "fill-color": "#d6e4ec" },
+        paint: { "fill-color": c.waterarea },
       },
       {
         id: "wstructurea-fill",
         type: "fill",
         source: SOURCE_ID,
         "source-layer": "wstructurea",
-        paint: { "fill-color": "#c8d7e0" },
+        paint: { "fill-color": c.wstructurea },
       },
       {
         id: "river-line",
         type: "line",
         source: SOURCE_ID,
         "source-layer": "river",
-        paint: { "line-color": "#88a7b8", "line-width": 0.8 },
+        paint: { "line-color": c.river, "line-width": 0.8 },
       },
       {
         id: "railway-line",
         type: "line",
         source: SOURCE_ID,
         "source-layer": "railway",
-        paint: { "line-color": "#666666", "line-width": 1.1 },
+        paint: { "line-color": c.railway, "line-width": 1.1 },
       },
       {
         id: "road-line",
@@ -65,7 +108,7 @@ export function buildBaseStyle(): StyleSpecification {
         source: SOURCE_ID,
         "source-layer": "road",
         paint: {
-          "line-color": "#bfbfbf",
+          "line-color": c.road,
           "line-width": [
             "interpolate",
             ["linear"],
@@ -85,7 +128,10 @@ export function buildBaseStyle(): StyleSpecification {
         source: SOURCE_ID,
         "source-layer": "building",
         minzoom: 13,
-        paint: { "fill-color": "#d8d3ca", "fill-outline-color": "#b5ae9f" },
+        paint: {
+          "fill-color": c.buildingFill,
+          "fill-outline-color": c.buildingOutline,
+        },
       },
       {
         id: "boundary-line",
@@ -93,7 +139,7 @@ export function buildBaseStyle(): StyleSpecification {
         source: SOURCE_ID,
         "source-layer": "boundary",
         paint: {
-          "line-color": "#9a9a9a",
+          "line-color": c.boundary,
           "line-width": 0.5,
           "line-dasharray": [3, 2],
         },

--- a/tests/e2e/display-and-export.spec.ts
+++ b/tests/e2e/display-and-export.spec.ts
@@ -33,6 +33,53 @@ test("map container renders and PNG export triggers a download", async ({ page }
   expect(suggested).toMatch(/^map-simplifier-\d{8}-\d{6}\.png$/);
 });
 
+test("preset toggle switches style name and keeps canvas visible", async ({ page }) => {
+  await page.goto("/");
+  await page.waitForFunction(() => document.body.dataset.mapReady === "true", null, {
+    timeout: 30_000,
+  });
+
+  // デフォルトは standard
+  const initial = await page.evaluate(() => {
+    const g = window as unknown as { __mlMap?: { getStyle(): { name?: string } } };
+    return g.__mlMap?.getStyle().name ?? null;
+  });
+  expect(initial).toBe("map-simplifier-standard");
+
+  // モノトーンへ切替
+  const monoBtn = page.locator("#preset-mono");
+  await expect(monoBtn).toBeVisible();
+  await monoBtn.click();
+
+  await page.waitForFunction(
+    () => {
+      const g = window as unknown as {
+        __mlMap?: { getStyle(): { name?: string }; isStyleLoaded(): boolean };
+      };
+      return !!g.__mlMap?.isStyleLoaded() && g.__mlMap.getStyle().name === "map-simplifier-mono";
+    },
+    null,
+    { timeout: 15_000 },
+  );
+
+  await expect(page.locator("#map canvas.maplibregl-canvas")).toBeVisible();
+
+  // 標準に戻す
+  await page.locator("#preset-standard").click();
+  await page.waitForFunction(
+    () => {
+      const g = window as unknown as {
+        __mlMap?: { getStyle(): { name?: string }; isStyleLoaded(): boolean };
+      };
+      return (
+        !!g.__mlMap?.isStyleLoaded() && g.__mlMap.getStyle().name === "map-simplifier-standard"
+      );
+    },
+    null,
+    { timeout: 15_000 },
+  );
+});
+
 test("URL hash reflects view state after pan", async ({ page }) => {
   await page.goto("/");
   await page.waitForFunction(() => document.body.dataset.mapReady === "true", null, {

--- a/tests/unit/style.test.ts
+++ b/tests/unit/style.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { buildBaseStyle, PRESETS, type Preset } from "../../src/map/style";
+
+// HEX -> {r,g,b} に分解して、R==G==B（グレースケール）かを判定するヘルパ。
+function isGrayscaleHex(hex: string): boolean {
+  const m = /^#([0-9a-f]{6})$/i.exec(hex);
+  if (!m) return false;
+  const n = parseInt(m[1]!, 16);
+  const r = (n >> 16) & 0xff;
+  const g = (n >> 8) & 0xff;
+  const b = n & 0xff;
+  return r === g && g === b;
+}
+
+describe("style presets", () => {
+  it("exposes the available presets", () => {
+    expect(PRESETS).toEqual(["standard", "mono"]);
+  });
+
+  it("defaults to 'standard' when no arg is passed (backward compat)", () => {
+    const def = buildBaseStyle();
+    const std = buildBaseStyle("standard");
+    expect(def).toEqual(std);
+  });
+
+  it.each<[Preset, string]>([
+    ["standard", "map-simplifier-standard"],
+    ["mono", "map-simplifier-mono"],
+  ])("preset %s has style name %s", (preset, expected) => {
+    expect(buildBaseStyle(preset).name).toBe(expected);
+  });
+
+  it("preset 'mono' has all fill-color / line-color as grayscale hex", () => {
+    const s = buildBaseStyle("mono");
+    const offending: string[] = [];
+    for (const layer of s.layers) {
+      const paint = ("paint" in layer ? layer.paint : undefined) as
+        | Record<string, unknown>
+        | undefined;
+      if (!paint) continue;
+      for (const key of ["fill-color", "line-color", "background-color", "fill-outline-color"]) {
+        const v = paint[key];
+        if (typeof v === "string") {
+          if (!isGrayscaleHex(v)) {
+            offending.push(`${layer.id}.${key}=${v}`);
+          }
+        }
+      }
+    }
+    expect(offending).toEqual([]);
+  });
+
+  it("preset 'mono' keeps the source config and attribution intact", () => {
+    const s = buildBaseStyle("mono");
+    expect(s.sources.gsi).toBeDefined();
+    // attribution は metadata に詰めている
+    expect(s.metadata).toMatchObject({ attribution: expect.stringMatching(/地理院/) });
+  });
+});


### PR DESCRIPTION
## Summary
- スタイルを preset 化し、グレースケール版「モノトーン」を追加
- ヘッダに「標準 / モノトーン」トグルを追加（aria-pressed で選択状態を表示）
- `map.setStyle({ diff: true })` で切替時にタイル再取得なし

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test`（単体 16 件 Green、うち style.test.ts は 6 件新設）
- [x] `pnpm e2e`（3 件 Green、うち preset toggle 1 件新設）
- [x] ブラウザ実機で「標準⇄モノトーン」切替を目視確認。モノトーン時に皇居・隅田川・鉄道の階層が紙面用途に適したグレー階調で描画されること

Closes #10
