### PR TITLE
chore: 軽量 CI（typecheck + vitest）と .npmrc の可搬化

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
     branches: [main]
   pull_request:
 
-# push した後に同じブランチへ続けて push すると前の実行はキャンセル。
+# 同一ブランチへの連続 push は古い実行をキャンセル。
 concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
@@ -18,16 +18,26 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # pnpm を先にセットアップしておく必要あり（setup-node の cache: pnpm 用）
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
-
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
-          cache: pnpm
+
+      # corepack で pnpm を有効化。pnpm/action-setup は repo の .npmrc に
+      # 引っぱられて挙動が不安定になる（虚 store に pnpm 自身を置く等）ため避ける。
+      - name: Enable pnpm
+        run: |
+          corepack enable
+          corepack prepare pnpm@10.33.0 --activate
+          pnpm -v
+
+      - name: Cache pnpm store
+        uses: actions/cache@v4
+        with:
+          path: ~/.local/share/pnpm/store
+          key: pnpm-store-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            pnpm-store-${{ runner.os }}-
 
       - name: Install
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+# push した後に同じブランチへ続けて push すると前の実行はキャンセル。
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  typecheck-and-unit:
+    name: typecheck + vitest
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      # pnpm を先にセットアップしておく必要あり（setup-node の cache: pnpm 用）
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - name: Install
+        run: pnpm install --frozen-lockfile
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+      - name: Unit tests
+        run: pnpm test

--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,3 @@
-store-dir=/Users/inuro/.local/share/pnpm/store
-virtual-store-dir=/Users/inuro/.local/share/map-simplifier-virtual-store
+store-dir=${HOME}/.local/share/pnpm/store
+virtual-store-dir=${HOME}/.local/share/map-simplifier-virtual-store
 node-linker=isolated


### PR DESCRIPTION
## Summary
- 軽量 CI（typecheck + vitest のみ）を追加。E2E は含めない
- `.npmrc` の絶対パスを `${HOME}` 補間に変更して CI Linux で動くように

## 意図
- past-self 保険。数週間ぶりに戻ってきたときに「壊れていない」保証を自動化
- E2E は外部タイル API の flaky 性を CI に持ち込みたくないため、手動 `pnpm e2e` のまま

## Test plan
- [x] ローカルで `pnpm install --frozen-lockfile` が `${HOME}` 補間後も動く
- [x] ローカルで `pnpm typecheck` / `pnpm test` が通る
- [ ] このPR上でGitHub Actions が緑になる（マージ前に確認）

Closes #6
