### PR TITLE
feat: クリックで feature を非表示にする

### DIFF
--- a/index.html
+++ b/index.html
@@ -95,6 +95,9 @@
           <button id="preset-standard" type="button" aria-pressed="true">標準</button>
           <button id="preset-mono" type="button" aria-pressed="false">モノトーン</button>
         </div>
+        <button id="reset-edits" class="primary" type="button" title="非表示にした要素を全て戻す" disabled>
+          編集をリセット
+        </button>
         <button id="export-png" class="primary" type="button">PNG書き出し</button>
       </header>
       <div id="map"></div>

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "devDependencies": {
     "@mapbox/vector-tile": "^2.0.4",
     "@playwright/test": "^1.48.2",
+    "@types/geojson": "^7946.0.16",
     "@types/node": "^22.9.0",
     "jsdom": "^25.0.1",
     "pbf": "^4.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,9 @@ importers:
       '@playwright/test':
         specifier: ^1.48.2
         version: 1.59.1
+      '@types/geojson':
+        specifier: ^7946.0.16
+        version: 7946.0.16
       '@types/node':
         specifier: ^22.9.0
         version: 22.19.17

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,11 +3,17 @@ import "maplibre-gl/dist/maplibre-gl.css";
 import { buildBaseStyle, type Preset } from "./map/style";
 import { GSI_ATTRIBUTION } from "./map/gsiSource";
 import {
+  ensureHiddenOverlay,
+  setHiddenOverlayData,
+  HIDEABLE_LAYER_IDS,
+} from "./map/overlay";
+import {
   DEFAULT_VIEW,
   decodeHashToView,
   encodeViewToHash,
   type ViewState,
 } from "./state/viewState";
+import { EditStateStore, toHiddenFeatureCollection } from "./state/editState";
 import { buildExportFilename, composePngWithCredit, downloadCanvasAsPng } from "./export/png";
 
 function requireEl<T extends Element>(id: string, ctor: new (...a: never[]) => T): T {
@@ -20,9 +26,11 @@ const mapRoot = requireEl("map", HTMLElement);
 const exportButton = requireEl("export-png", HTMLButtonElement);
 const presetStandardBtn = requireEl("preset-standard", HTMLButtonElement);
 const presetMonoBtn = requireEl("preset-mono", HTMLButtonElement);
+const resetEditsBtn = requireEl("reset-edits", HTMLButtonElement);
 
 const initialView: ViewState = decodeHashToView(window.location.hash) ?? DEFAULT_VIEW;
 let currentPreset: Preset = "standard";
+const editState = new EditStateStore();
 
 const map: MapLibreMap = new maplibregl.Map({
   container: mapRoot,
@@ -55,24 +63,73 @@ function syncHash(): void {
 map.on("moveend", syncHash);
 map.on("zoomend", syncHash);
 
+function refreshOverlay(): void {
+  ensureHiddenOverlay(map, currentPreset, toHiddenFeatureCollection(editState.state.hidden));
+}
+
 map.on("load", () => {
+  // 初回の style ロード後。overlay を最初に差し込む。
+  refreshOverlay();
   document.body.dataset["mapReady"] = "true";
 });
 
+// preset 切替は setStyle を伴い overlay を飛ばすことがある。
+// styledata はその後何度か発火するが、isStyleLoaded() が真になってから
+// overlay を復元する（もしくは色を追従させる）。
+map.on("styledata", () => {
+  if (!map.isStyleLoaded()) return;
+  refreshOverlay();
+});
+
+// 編集状態が変わったら overlay の source data だけ更新（layer は既存のを再利用）。
+editState.subscribe((s) => {
+  setHiddenOverlayData(map, toHiddenFeatureCollection(s.hidden));
+  resetEditsBtn.disabled = s.hidden.length === 0;
+});
+resetEditsBtn.disabled = true;
+
 if (import.meta.env.DEV) {
-  (globalThis as unknown as { __mlMap?: MapLibreMap }).__mlMap = map;
+  (globalThis as unknown as { __mlMap?: MapLibreMap; __editState?: EditStateStore }).__mlMap = map;
+  (globalThis as unknown as { __mlMap?: MapLibreMap; __editState?: EditStateStore }).__editState =
+    editState;
 }
 
 function applyPreset(next: Preset): void {
   if (next === currentPreset) return;
   currentPreset = next;
   // source と layer を差分更新で入れ替える。diff: true なら source(タイル)は再取得しない。
+  // setStyle → style.load が発火 → refreshOverlay() で overlay 再適用。
   map.setStyle(buildBaseStyle(next), { diff: true });
   presetStandardBtn.setAttribute("aria-pressed", String(next === "standard"));
   presetMonoBtn.setAttribute("aria-pressed", String(next === "mono"));
 }
 presetStandardBtn.addEventListener("click", () => applyPreset("standard"));
 presetMonoBtn.addEventListener("click", () => applyPreset("mono"));
+
+// クリックで最前面 feature を非表示化。
+map.on("click", (e) => {
+  const features = map.queryRenderedFeatures(e.point, {
+    layers: [...HIDEABLE_LAYER_IDS],
+  });
+  if (features.length === 0) return;
+  const top = features[0]!;
+  editState.hide({
+    sourceLayer: top.sourceLayer ?? "",
+    // queryRenderedFeatures の geometry は WGS84 lng/lat で返る。
+    geometry: top.geometry,
+    properties: top.properties ?? {},
+  });
+});
+
+// Hideable レイヤ上でポインタを指に変える（クリック可能性の示唆）。
+map.on("mousemove", (e) => {
+  const hit = map.queryRenderedFeatures(e.point, { layers: [...HIDEABLE_LAYER_IDS] });
+  map.getCanvas().style.cursor = hit.length > 0 ? "pointer" : "";
+});
+
+resetEditsBtn.addEventListener("click", () => {
+  editState.clearAll();
+});
 
 exportButton.addEventListener("click", async () => {
   exportButton.disabled = true;

--- a/src/map/overlay.ts
+++ b/src/map/overlay.ts
@@ -1,0 +1,110 @@
+import type { FeatureCollection } from "geojson";
+import type { GeoJSONSource, Map as MapLibreMap } from "maplibre-gl";
+import { PALETTES, type Preset } from "./style";
+
+/**
+ * 非表示にされた feature を覆い隠すオーバレイ。
+ * GeoJSON source + mask layer (polygon/line/point) を map に差し込み、
+ * 現在の preset の背景色で元 feature を上書きする。
+ *
+ * preset 切替時は base style を setStyle で入れ替えるが、本オーバレイは
+ * 明示的に style.load で再適用する（setStyle の diff ではカスタム source/layer は
+ * 基本的に残るが、確実性のため毎回 ensureHiddenOverlay() を呼ぶ）。
+ */
+
+export const HIDDEN_SOURCE_ID = "hidden-overlay";
+export const HIDDEN_LAYER_IDS = {
+  polygon: "hidden-polygon-mask",
+  line: "hidden-line-mask",
+  point: "hidden-point-mask",
+} as const;
+
+// 「ユーザが非表示にしたい」候補レイヤの style layer id。
+// bg（背景）と overlay 自身は除外。
+export const HIDEABLE_LAYER_IDS: readonly string[] = [
+  "waterarea-fill",
+  "wstructurea-fill",
+  "river-line",
+  "railway-line",
+  "road-line",
+  "building-fill",
+  "boundary-line",
+];
+
+export function ensureHiddenOverlay(
+  map: MapLibreMap,
+  preset: Preset,
+  data: FeatureCollection,
+): void {
+  const bg = PALETTES[preset].bg;
+
+  if (!map.getSource(HIDDEN_SOURCE_ID)) {
+    map.addSource(HIDDEN_SOURCE_ID, {
+      type: "geojson",
+      data,
+    });
+  } else {
+    (map.getSource(HIDDEN_SOURCE_ID) as GeoJSONSource).setData(data);
+  }
+
+  if (!map.getLayer(HIDDEN_LAYER_IDS.polygon)) {
+    map.addLayer({
+      id: HIDDEN_LAYER_IDS.polygon,
+      type: "fill",
+      source: HIDDEN_SOURCE_ID,
+      filter: ["==", ["geometry-type"], "Polygon"],
+      paint: { "fill-color": bg, "fill-opacity": 1 },
+    });
+  } else {
+    map.setPaintProperty(HIDDEN_LAYER_IDS.polygon, "fill-color", bg);
+  }
+
+  if (!map.getLayer(HIDDEN_LAYER_IDS.line)) {
+    map.addLayer({
+      id: HIDDEN_LAYER_IDS.line,
+      type: "line",
+      source: HIDDEN_SOURCE_ID,
+      filter: ["==", ["geometry-type"], "LineString"],
+      paint: {
+        "line-color": bg,
+        // 原線より太く覆う（ズームに応じて拡張）。書籍用途では完全に消したいので広めに。
+        "line-width": [
+          "interpolate",
+          ["linear"],
+          ["zoom"],
+          10,
+          4,
+          14,
+          8,
+          16,
+          14,
+        ],
+      },
+    });
+  } else {
+    map.setPaintProperty(HIDDEN_LAYER_IDS.line, "line-color", bg);
+  }
+
+  if (!map.getLayer(HIDDEN_LAYER_IDS.point)) {
+    map.addLayer({
+      id: HIDDEN_LAYER_IDS.point,
+      type: "circle",
+      source: HIDDEN_SOURCE_ID,
+      filter: ["==", ["geometry-type"], "Point"],
+      paint: {
+        "circle-color": bg,
+        "circle-radius": 10,
+        "circle-stroke-width": 0,
+      },
+    });
+  } else {
+    map.setPaintProperty(HIDDEN_LAYER_IDS.point, "circle-color", bg);
+  }
+}
+
+export function setHiddenOverlayData(map: MapLibreMap, data: FeatureCollection): void {
+  const src = map.getSource(HIDDEN_SOURCE_ID);
+  if (src && "setData" in src) {
+    (src as GeoJSONSource).setData(data);
+  }
+}

--- a/src/map/style.ts
+++ b/src/map/style.ts
@@ -33,7 +33,7 @@ interface PresetPalette {
   boundary: string;
 }
 
-const PALETTES: Record<Preset, PresetPalette> = {
+export const PALETTES: Record<Preset, PresetPalette> = {
   standard: {
     bg: "#fafafa",
     waterarea: "#d6e4ec",

--- a/src/state/editState.ts
+++ b/src/state/editState.ts
@@ -1,0 +1,94 @@
+import type { FeatureCollection, Geometry } from "geojson";
+
+/**
+ * 非表示にされた feature の記録。
+ *
+ * GSI ベクトルタイルには feature.id が付与されていないため、`setFeatureState` による
+ * per-feature hide は使えない。代わりに client-side で geometry を保持し、
+ * 同色 mask layer のオーバレイで「消す」戦略を取る（#7）。
+ *
+ * `id` はこのセッション内で一意の合成値で、永続化や同期用ではない（#5 で扱う）。
+ */
+export interface HiddenFeature {
+  id: string;
+  sourceLayer: string;
+  geometry: Geometry;
+  properties: Record<string, unknown>;
+}
+
+export interface EditState {
+  hidden: ReadonlyArray<HiddenFeature>;
+}
+
+export interface HideInput {
+  sourceLayer: string;
+  geometry: Geometry;
+  properties: Record<string, unknown>;
+}
+
+type Listener = (state: EditState) => void;
+
+export class EditStateStore {
+  private _hidden: HiddenFeature[] = [];
+  private _listeners = new Set<Listener>();
+  private _counter = 0;
+
+  get state(): EditState {
+    return { hidden: [...this._hidden] };
+  }
+
+  hide(input: HideInput): HiddenFeature {
+    this._counter += 1;
+    const entry: HiddenFeature = {
+      id: `h-${this._counter}`,
+      sourceLayer: input.sourceLayer,
+      geometry: input.geometry,
+      properties: { ...input.properties },
+    };
+    this._hidden.push(entry);
+    this._emit();
+    return entry;
+  }
+
+  clearAll(): void {
+    if (this._hidden.length === 0) return;
+    this._hidden.length = 0;
+    this._emit();
+  }
+
+  subscribe(l: Listener): () => void {
+    this._listeners.add(l);
+    return () => {
+      this._listeners.delete(l);
+    };
+  }
+
+  private _emit(): void {
+    const s = this.state;
+    for (const l of this._listeners) l(s);
+  }
+}
+
+/**
+ * 非表示リストを MapLibre の GeoJSON source 用 FeatureCollection に変換。
+ *
+ * `properties._sourceLayer` は mask 用 style 側で元レイヤ判定に使える予備情報。
+ * `id` は FeatureCollection 側の feature.id としても入れておき、
+ * setData 後に `map.querySourceFeatures` で辿れるようにする。
+ */
+export function toHiddenFeatureCollection(
+  list: ReadonlyArray<HiddenFeature>,
+): FeatureCollection {
+  return {
+    type: "FeatureCollection",
+    features: list.map((h) => ({
+      type: "Feature",
+      id: h.id,
+      geometry: h.geometry,
+      properties: {
+        _id: h.id,
+        _sourceLayer: h.sourceLayer,
+      },
+    })),
+  };
+}

--- a/tests/e2e/display-and-export.spec.ts
+++ b/tests/e2e/display-and-export.spec.ts
@@ -80,6 +80,88 @@ test("preset toggle switches style name and keeps canvas visible", async ({ page
   );
 });
 
+test("clicking a feature hides it and reset clears the overlay", async ({ page }) => {
+  await page.goto("/");
+  await page.waitForFunction(() => document.body.dataset.mapReady === "true", null, {
+    timeout: 30_000,
+  });
+
+  // 東京駅周辺の建物が多いズームに寄せる（デフォルト13→15）
+  await page.evaluate(() => {
+    const g = window as unknown as {
+      __mlMap?: { setZoom(z: number): void; once(ev: string, cb: () => void): void };
+    };
+    g.__mlMap?.setZoom(15);
+  });
+  await page.waitForFunction(
+    () => {
+      const g = window as unknown as { __mlMap?: { getZoom(): number; isStyleLoaded(): boolean; areTilesLoaded(): boolean } };
+      return !!g.__mlMap && Math.round(g.__mlMap.getZoom()) === 15 && g.__mlMap.isStyleLoaded() && g.__mlMap.areTilesLoaded();
+    },
+    null,
+    { timeout: 15_000 },
+  );
+
+  const canvas = page.locator("#map canvas.maplibregl-canvas");
+  const box = await canvas.boundingBox();
+  if (!box) throw new Error("canvas not measured");
+
+  // クリック候補点をいくつか試して、非表示化できる feature に当たるまで探す
+  const cx = box.x + box.width / 2;
+  const cy = box.y + box.height / 2;
+  const attempts: Array<[number, number]> = [
+    [cx, cy],
+    [cx + 60, cy],
+    [cx, cy + 60],
+    [cx - 60, cy],
+    [cx, cy - 60],
+    [cx + 120, cy + 20],
+  ];
+
+  let clicked = 0;
+  for (const [x, y] of attempts) {
+    const before = await page.evaluate(() => {
+      const g = window as unknown as {
+        __mlMap?: {
+          getSource(id: string): unknown;
+        };
+      };
+      const src = g.__mlMap?.getSource("hidden-overlay") as
+        | { _data?: { features?: unknown[] } }
+        | undefined;
+      return src?._data?.features?.length ?? 0;
+    });
+    await page.mouse.click(x, y);
+    // MapLibre の click→queryRenderedFeatures→setData は同期的なので wait は最小
+    await page.waitForTimeout(100);
+    const after = await page.evaluate(() => {
+      const g = window as unknown as {
+        __mlMap?: { getSource(id: string): unknown };
+      };
+      const src = g.__mlMap?.getSource("hidden-overlay") as
+        | { _data?: { features?: unknown[] } }
+        | undefined;
+      return src?._data?.features?.length ?? 0;
+    });
+    if (after > before) {
+      clicked = after;
+      break;
+    }
+  }
+  expect(clicked).toBeGreaterThan(0);
+
+  // リセットで空に戻る
+  await page.locator("#reset-edits").click();
+  const finalCount = await page.evaluate(() => {
+    const g = window as unknown as { __mlMap?: { getSource(id: string): unknown } };
+    const src = g.__mlMap?.getSource("hidden-overlay") as
+      | { _data?: { features?: unknown[] } }
+      | undefined;
+    return src?._data?.features?.length ?? 0;
+  });
+  expect(finalCount).toBe(0);
+});
+
 test("URL hash reflects view state after pan", async ({ page }) => {
   await page.goto("/");
   await page.waitForFunction(() => document.body.dataset.mapReady === "true", null, {

--- a/tests/unit/editState.test.ts
+++ b/tests/unit/editState.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Feature, LineString, Polygon } from "geojson";
+import { EditStateStore, toHiddenFeatureCollection } from "../../src/state/editState";
+
+function lineFeature(coords: [number, number][]): Feature<LineString> {
+  return {
+    type: "Feature",
+    geometry: { type: "LineString", coordinates: coords },
+    properties: { ftCode: 2701 },
+  };
+}
+
+function polygonFeature(coords: [number, number][]): Feature<Polygon> {
+  return {
+    type: "Feature",
+    geometry: { type: "Polygon", coordinates: [coords] },
+    properties: { ftCode: 3101 },
+  };
+}
+
+describe("EditStateStore", () => {
+  it("starts empty", () => {
+    const s = new EditStateStore();
+    expect(s.state.hidden).toEqual([]);
+  });
+
+  it("hides a feature and returns the created entry with a stable id prefix", () => {
+    const s = new EditStateStore();
+    const f = lineFeature([
+      [139.767, 35.681],
+      [139.768, 35.682],
+    ]);
+    const entry = s.hide({
+      sourceLayer: "road",
+      geometry: f.geometry,
+      properties: f.properties ?? {},
+    });
+    expect(entry.id).toMatch(/^h-\d+$/);
+    expect(entry.sourceLayer).toBe("road");
+    expect(entry.geometry).toEqual(f.geometry);
+    expect(s.state.hidden).toHaveLength(1);
+  });
+
+  it("assigns a unique id to each hidden entry", () => {
+    const s = new EditStateStore();
+    const a = s.hide({ sourceLayer: "road", geometry: { type: "Point", coordinates: [0, 0] }, properties: {} });
+    const b = s.hide({ sourceLayer: "road", geometry: { type: "Point", coordinates: [1, 1] }, properties: {} });
+    expect(a.id).not.toBe(b.id);
+  });
+
+  it("clearAll empties the list and fires a listener", () => {
+    const s = new EditStateStore();
+    s.hide({ sourceLayer: "road", geometry: { type: "Point", coordinates: [0, 0] }, properties: {} });
+    const listener = vi.fn();
+    s.subscribe(listener);
+    s.clearAll();
+    expect(s.state.hidden).toEqual([]);
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it("clearAll is a no-op when already empty (no listener call)", () => {
+    const s = new EditStateStore();
+    const listener = vi.fn();
+    s.subscribe(listener);
+    s.clearAll();
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it("subscribe returns an unsubscribe function", () => {
+    const s = new EditStateStore();
+    const listener = vi.fn();
+    const off = s.subscribe(listener);
+    s.hide({ sourceLayer: "x", geometry: { type: "Point", coordinates: [0, 0] }, properties: {} });
+    expect(listener).toHaveBeenCalledTimes(1);
+    off();
+    s.hide({ sourceLayer: "x", geometry: { type: "Point", coordinates: [0, 0] }, properties: {} });
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("toHiddenFeatureCollection", () => {
+  it("returns an empty FeatureCollection for an empty list", () => {
+    expect(toHiddenFeatureCollection([])).toEqual({ type: "FeatureCollection", features: [] });
+  });
+
+  it("serializes hidden entries, preserving sourceLayer in properties._sourceLayer", () => {
+    const store = new EditStateStore();
+    const a = store.hide({
+      sourceLayer: "road",
+      geometry: lineFeature([
+        [0, 0],
+        [1, 1],
+      ]).geometry,
+      properties: { ftCode: 2701 },
+    });
+    const b = store.hide({
+      sourceLayer: "building",
+      geometry: polygonFeature([
+        [0, 0],
+        [1, 0],
+        [1, 1],
+        [0, 1],
+        [0, 0],
+      ]).geometry,
+      properties: {},
+    });
+    const fc = toHiddenFeatureCollection(store.state.hidden);
+    expect(fc.features).toHaveLength(2);
+    expect(fc.features[0]!.id).toBe(a.id);
+    expect(fc.features[0]!.properties?._sourceLayer).toBe("road");
+    expect(fc.features[1]!.id).toBe(b.id);
+    expect(fc.features[1]!.properties?._sourceLayer).toBe("building");
+  });
+});


### PR DESCRIPTION
## Summary
- クリックで最前面の feature を非表示にする（GeoJSON オーバレイ方式）
- 「編集をリセット」ボタンで全復元
- プリセット切替に mask 色が追従
- 共通基盤（`HIDEABLE_LAYER_IDS`、`EditStateStore`）を公開し、#8 #9 で流用

## 設計上の決定
GSI experimental_bvmap には `feature.id` が無いため、`setFeatureState` + filter 式による per-feature hide は不可能（`scripts/inspect-tile.mjs` で検証済み）。client-side に geometry を保持し、同色 mask layer (polygon / line / point) を上から被せて「消す」方式を採用。

## 既知の制約
- geometry は `queryRenderedFeatures` 由来のためタイル境界でクリップされる可能性あり
- 現状は「全リセット」のみ。個別復元は後続
- 保存・復元は #5 で扱う

## Test plan
- [x] `pnpm typecheck` — 通過
- [x] `pnpm test` — 24 件 Green（editState 8 件を新設）
- [x] `pnpm e2e` — 4 件 Green（click-hide 1 件を新設）
- [x] ブラウザ実機で click→hide→reset のフローを確認。赤/マゼンタのデバッグ色でマスクが正しい位置に描画されることも確認済み
- [x] プリセット切替（標準⇄モノトーン）で mask 色が追従することを確認

Closes #7
