### PR TITLE
feat: 選択モデル（click=select / shift+click=multi / Esc=clear）

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,6 +37,12 @@
       header .spacer {
         flex: 1;
       }
+      .selection-count {
+        font-size: 12px;
+        color: #666;
+        min-width: 6em;
+        text-align: right;
+      }
       button.primary {
         appearance: none;
         border: 1px solid #888;
@@ -90,6 +96,7 @@
     <div id="app">
       <header>
         <h1>map-simplifier</h1>
+        <span id="selection-count" class="selection-count" aria-live="polite"></span>
         <span class="spacer"></span>
         <div class="preset-group" role="group" aria-label="スタイルプリセット">
           <button id="preset-standard" type="button" aria-pressed="true">標準</button>

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,12 +8,17 @@ import {
   HIDEABLE_LAYER_IDS,
 } from "./map/overlay";
 import {
+  ensureSelectionOverlay,
+  setSelectionOverlayData,
+} from "./map/selectionOverlay";
+import {
   DEFAULT_VIEW,
   decodeHashToView,
   encodeViewToHash,
   type ViewState,
 } from "./state/viewState";
 import { EditStateStore, toHiddenFeatureCollection } from "./state/editState";
+import { SelectionStore, toSelectionFeatureCollection } from "./state/selectionStore";
 import { buildExportFilename, composePngWithCredit, downloadCanvasAsPng } from "./export/png";
 
 function requireEl<T extends Element>(id: string, ctor: new (...a: never[]) => T): T {
@@ -27,10 +32,12 @@ const exportButton = requireEl("export-png", HTMLButtonElement);
 const presetStandardBtn = requireEl("preset-standard", HTMLButtonElement);
 const presetMonoBtn = requireEl("preset-mono", HTMLButtonElement);
 const resetEditsBtn = requireEl("reset-edits", HTMLButtonElement);
+const selectionCountEl = requireEl("selection-count", HTMLSpanElement);
 
 const initialView: ViewState = decodeHashToView(window.location.hash) ?? DEFAULT_VIEW;
 let currentPreset: Preset = "standard";
 const editState = new EditStateStore();
+const selectionStore = new SelectionStore();
 
 const map: MapLibreMap = new maplibregl.Map({
   container: mapRoot,
@@ -63,13 +70,13 @@ function syncHash(): void {
 map.on("moveend", syncHash);
 map.on("zoomend", syncHash);
 
-function refreshOverlay(): void {
+function refreshOverlays(): void {
   ensureHiddenOverlay(map, currentPreset, toHiddenFeatureCollection(editState.state.hidden));
+  ensureSelectionOverlay(map, toSelectionFeatureCollection(selectionStore.state));
 }
 
 map.on("load", () => {
-  // 初回の style ロード後。overlay を最初に差し込む。
-  refreshOverlay();
+  refreshOverlays();
   document.body.dataset["mapReady"] = "true";
 });
 
@@ -78,27 +85,41 @@ map.on("load", () => {
 // overlay を復元する（もしくは色を追従させる）。
 map.on("styledata", () => {
   if (!map.isStyleLoaded()) return;
-  refreshOverlay();
+  refreshOverlays();
 });
 
-// 編集状態が変わったら overlay の source data だけ更新（layer は既存のを再利用）。
+// 編集状態が変わったら hidden overlay の data を更新。
 editState.subscribe((s) => {
   setHiddenOverlayData(map, toHiddenFeatureCollection(s.hidden));
   resetEditsBtn.disabled = s.hidden.length === 0;
 });
 resetEditsBtn.disabled = true;
 
+// 選択状態が変わったら selection overlay の data と選択数表示を更新。
+function updateSelectionUI(): void {
+  const n = selectionStore.state.length;
+  selectionCountEl.textContent = n > 0 ? `選択: ${n}` : "";
+  setSelectionOverlayData(map, toSelectionFeatureCollection(selectionStore.state));
+}
+selectionStore.subscribe(() => updateSelectionUI());
+updateSelectionUI();
+
 if (import.meta.env.DEV) {
-  (globalThis as unknown as { __mlMap?: MapLibreMap; __editState?: EditStateStore }).__mlMap = map;
-  (globalThis as unknown as { __mlMap?: MapLibreMap; __editState?: EditStateStore }).__editState =
-    editState;
+  const w = globalThis as unknown as {
+    __mlMap?: MapLibreMap;
+    __editState?: EditStateStore;
+    __selectionStore?: SelectionStore;
+  };
+  w.__mlMap = map;
+  w.__editState = editState;
+  w.__selectionStore = selectionStore;
 }
 
 function applyPreset(next: Preset): void {
   if (next === currentPreset) return;
   currentPreset = next;
   // source と layer を差分更新で入れ替える。diff: true なら source(タイル)は再取得しない。
-  // setStyle → style.load が発火 → refreshOverlay() で overlay 再適用。
+  // setStyle → styledata が発火 → refreshOverlays() で overlay 再適用。
   map.setStyle(buildBaseStyle(next), { diff: true });
   presetStandardBtn.setAttribute("aria-pressed", String(next === "standard"));
   presetMonoBtn.setAttribute("aria-pressed", String(next === "mono"));
@@ -106,25 +127,48 @@ function applyPreset(next: Preset): void {
 presetStandardBtn.addEventListener("click", () => applyPreset("standard"));
 presetMonoBtn.addEventListener("click", () => applyPreset("mono"));
 
-// クリックで最前面 feature を非表示化。
+// クリックで feature を選択。shift+click で toggle（追加/解除）。
+// 空所クリックは選択解除。
+//
+// queryRenderedFeatures の第1引数は PointLike（[x, y] or {x, y}）。
+// e.point は {x, y} オブジェクトだが、そのまま渡すと MapLibre 内部で
+// 「options」として解釈されて viewport 全体走査になるケースがある。
+// 明示的に [x, y] 配列化する。
 map.on("click", (e) => {
-  const features = map.queryRenderedFeatures(e.point, {
+  const pt: [number, number] = [e.point.x, e.point.y];
+  const features = map.queryRenderedFeatures(pt, {
     layers: [...HIDEABLE_LAYER_IDS],
   });
-  if (features.length === 0) return;
+  if (features.length === 0) {
+    selectionStore.clear();
+    return;
+  }
   const top = features[0]!;
-  editState.hide({
+  const input = {
     sourceLayer: top.sourceLayer ?? "",
-    // queryRenderedFeatures の geometry は WGS84 lng/lat で返る。
     geometry: top.geometry,
     properties: top.properties ?? {},
-  });
+  };
+  const shift = e.originalEvent?.shiftKey ?? false;
+  if (shift) {
+    selectionStore.toggle(input);
+  } else {
+    selectionStore.selectOne(input);
+  }
 });
 
 // Hideable レイヤ上でポインタを指に変える（クリック可能性の示唆）。
 map.on("mousemove", (e) => {
-  const hit = map.queryRenderedFeatures(e.point, { layers: [...HIDEABLE_LAYER_IDS] });
+  const pt: [number, number] = [e.point.x, e.point.y];
+  const hit = map.queryRenderedFeatures(pt, { layers: [...HIDEABLE_LAYER_IDS] });
   map.getCanvas().style.cursor = hit.length > 0 ? "pointer" : "";
+});
+
+// Esc キーで選択解除。
+window.addEventListener("keydown", (e) => {
+  if (e.key === "Escape") {
+    selectionStore.clear();
+  }
 });
 
 resetEditsBtn.addEventListener("click", () => {

--- a/src/map/selectionOverlay.ts
+++ b/src/map/selectionOverlay.ts
@@ -1,0 +1,79 @@
+import type { FeatureCollection } from "geojson";
+import type { GeoJSONSource, Map as MapLibreMap } from "maplibre-gl";
+
+/**
+ * 選択中 feature を視覚的に示すオーバレイ。
+ * hidden-overlay（#7）の隣に、橙色の「縁取り」レイヤ群を置く。
+ *
+ * preset 非依存の固定色で、標準／モノトーンどちらでも視認できることを狙う。
+ */
+
+export const SELECTION_SOURCE_ID = "selection-overlay";
+export const SELECTION_LAYER_IDS = {
+  polygonStroke: "selection-polygon-stroke",
+  line: "selection-line",
+  point: "selection-point",
+} as const;
+
+const SELECTION_COLOR = "#ff8800";
+
+export function ensureSelectionOverlay(map: MapLibreMap, data: FeatureCollection): void {
+  if (!map.getSource(SELECTION_SOURCE_ID)) {
+    map.addSource(SELECTION_SOURCE_ID, {
+      type: "geojson",
+      data,
+    });
+  } else {
+    (map.getSource(SELECTION_SOURCE_ID) as GeoJSONSource).setData(data);
+  }
+
+  // Polygon: 塗りは薄い橙、境界線を太く強調
+  if (!map.getLayer(SELECTION_LAYER_IDS.polygonStroke)) {
+    map.addLayer({
+      id: SELECTION_LAYER_IDS.polygonStroke,
+      type: "line",
+      source: SELECTION_SOURCE_ID,
+      filter: ["==", ["geometry-type"], "Polygon"],
+      paint: {
+        "line-color": SELECTION_COLOR,
+        "line-width": 3,
+      },
+    });
+  }
+
+  if (!map.getLayer(SELECTION_LAYER_IDS.line)) {
+    map.addLayer({
+      id: SELECTION_LAYER_IDS.line,
+      type: "line",
+      source: SELECTION_SOURCE_ID,
+      filter: ["==", ["geometry-type"], "LineString"],
+      paint: {
+        "line-color": SELECTION_COLOR,
+        "line-width": 4,
+        "line-opacity": 0.9,
+      },
+    });
+  }
+
+  if (!map.getLayer(SELECTION_LAYER_IDS.point)) {
+    map.addLayer({
+      id: SELECTION_LAYER_IDS.point,
+      type: "circle",
+      source: SELECTION_SOURCE_ID,
+      filter: ["==", ["geometry-type"], "Point"],
+      paint: {
+        "circle-color": "#ffffff",
+        "circle-stroke-color": SELECTION_COLOR,
+        "circle-stroke-width": 3,
+        "circle-radius": 7,
+      },
+    });
+  }
+}
+
+export function setSelectionOverlayData(map: MapLibreMap, data: FeatureCollection): void {
+  const src = map.getSource(SELECTION_SOURCE_ID);
+  if (src && "setData" in src) {
+    (src as GeoJSONSource).setData(data);
+  }
+}

--- a/src/state/selectionStore.ts
+++ b/src/state/selectionStore.ts
@@ -1,0 +1,111 @@
+import type { FeatureCollection, Geometry } from "geojson";
+
+/**
+ * 選択状態の管理。編集アクション（#16 削除, #19 強調, #9 ラベル）はこの選択状態に対して作用する。
+ *
+ * GSI ベクトルタイルには feature.id が無いため、選択の同一性は
+ * `sourceLayer` と `geometry` の deep-equality で判定する。
+ * geometry は queryRenderedFeatures 由来のため、同一 feature の同一タイルでの
+ * クリックなら安定して一致する（MVP の割り切り）。
+ */
+
+export interface SelectedFeatureInput {
+  sourceLayer: string;
+  geometry: Geometry;
+  properties: Record<string, unknown>;
+}
+
+export interface SelectedFeature extends SelectedFeatureInput {
+  id: string;
+}
+
+type Listener = (state: ReadonlyArray<SelectedFeature>) => void;
+
+/**
+ * sourceLayer + geometry で同一性を判定するためのキー。
+ * geometry の JSON 表現をそのまま使う（coordinates は配列なので順序は安定）。
+ */
+function keyOf(f: SelectedFeatureInput): string {
+  return `${f.sourceLayer}::${JSON.stringify(f.geometry)}`;
+}
+
+export class SelectionStore {
+  private _items: SelectedFeature[] = [];
+  private _listeners = new Set<Listener>();
+  private _counter = 0;
+
+  get state(): ReadonlyArray<SelectedFeature> {
+    return this._items;
+  }
+
+  /** 既存選択をクリアして単一選択に置き換え。 */
+  selectOne(f: SelectedFeatureInput): void {
+    this._items = [this._build(f)];
+    this._emit();
+  }
+
+  /** 既存選択に追加（同一 feature はスキップ）。 */
+  add(f: SelectedFeatureInput): void {
+    const k = keyOf(f);
+    if (this._items.some((i) => keyOf(i) === k)) return;
+    this._items = [...this._items, this._build(f)];
+    this._emit();
+  }
+
+  /** 存在すれば削除、なければ追加。 */
+  toggle(f: SelectedFeatureInput): void {
+    const k = keyOf(f);
+    const idx = this._items.findIndex((i) => keyOf(i) === k);
+    if (idx >= 0) {
+      this._items = [...this._items.slice(0, idx), ...this._items.slice(idx + 1)];
+    } else {
+      this._items = [...this._items, this._build(f)];
+    }
+    this._emit();
+  }
+
+  clear(): void {
+    if (this._items.length === 0) return;
+    this._items = [];
+    this._emit();
+  }
+
+  subscribe(l: Listener): () => void {
+    this._listeners.add(l);
+    return () => {
+      this._listeners.delete(l);
+    };
+  }
+
+  private _build(f: SelectedFeatureInput): SelectedFeature {
+    this._counter += 1;
+    return {
+      id: `s-${this._counter}`,
+      sourceLayer: f.sourceLayer,
+      geometry: f.geometry,
+      properties: { ...f.properties },
+    };
+  }
+
+  private _emit(): void {
+    const snapshot = this._items;
+    for (const l of this._listeners) l(snapshot);
+  }
+}
+
+export function toSelectionFeatureCollection(
+  list: ReadonlyArray<SelectedFeature>,
+): FeatureCollection {
+  return {
+    type: "FeatureCollection",
+    features: list.map((s) => ({
+      type: "Feature",
+      id: s.id,
+      geometry: s.geometry,
+      properties: {
+        _id: s.id,
+        _sourceLayer: s.sourceLayer,
+      },
+    })),
+  };
+}

--- a/tests/e2e/display-and-export.spec.ts
+++ b/tests/e2e/display-and-export.spec.ts
@@ -80,86 +80,124 @@ test("preset toggle switches style name and keeps canvas visible", async ({ page
   );
 });
 
-test("clicking a feature hides it and reset clears the overlay", async ({ page }) => {
+test("clicking a feature selects it; shift+click adds; Esc clears", async ({ page }) => {
   await page.goto("/");
   await page.waitForFunction(() => document.body.dataset.mapReady === "true", null, {
     timeout: 30_000,
   });
 
-  // 東京駅周辺の建物が多いズームに寄せる（デフォルト13→15）
+  // 建物が多い zoom に寄せる
   await page.evaluate(() => {
-    const g = window as unknown as {
-      __mlMap?: { setZoom(z: number): void; once(ev: string, cb: () => void): void };
-    };
+    const g = window as unknown as { __mlMap?: { setZoom(z: number): void } };
     g.__mlMap?.setZoom(15);
   });
   await page.waitForFunction(
     () => {
-      const g = window as unknown as { __mlMap?: { getZoom(): number; isStyleLoaded(): boolean; areTilesLoaded(): boolean } };
-      return !!g.__mlMap && Math.round(g.__mlMap.getZoom()) === 15 && g.__mlMap.isStyleLoaded() && g.__mlMap.areTilesLoaded();
+      const g = window as unknown as {
+        __mlMap?: {
+          getZoom(): number;
+          isStyleLoaded(): boolean;
+          areTilesLoaded(): boolean;
+        };
+      };
+      return (
+        !!g.__mlMap &&
+        Math.round(g.__mlMap.getZoom()) === 15 &&
+        g.__mlMap.isStyleLoaded() &&
+        g.__mlMap.areTilesLoaded()
+      );
     },
     null,
     { timeout: 15_000 },
   );
 
-  const canvas = page.locator("#map canvas.maplibregl-canvas");
-  const box = await canvas.boundingBox();
-  if (!box) throw new Error("canvas not measured");
-
-  // クリック候補点をいくつか試して、非表示化できる feature に当たるまで探す
-  const cx = box.x + box.width / 2;
-  const cy = box.y + box.height / 2;
-  const attempts: Array<[number, number]> = [
-    [cx, cy],
-    [cx + 60, cy],
-    [cx, cy + 60],
-    [cx - 60, cy],
-    [cx, cy - 60],
-    [cx + 120, cy + 20],
-  ];
-
-  let clicked = 0;
-  for (const [x, y] of attempts) {
-    const before = await page.evaluate(() => {
-      const g = window as unknown as {
-        __mlMap?: {
-          getSource(id: string): unknown;
-        };
+  // 2 つの "異なる feature" にヒットする座標を事前に探しておく。
+  // タイルごとに feature が異なるので、画面全体をスキャンして
+  // top feature の geometry が異なる2点を見つける。
+  const hits = await page.evaluate(() => {
+    const g = window as unknown as {
+      __mlMap?: {
+        queryRenderedFeatures(
+          p: [number, number],
+          opts?: { layers?: string[] },
+        ): Array<{ geometry: unknown; layer: { id: string } }>;
       };
-      const src = g.__mlMap?.getSource("hidden-overlay") as
-        | { _data?: { features?: unknown[] } }
-        | undefined;
-      return src?._data?.features?.length ?? 0;
-    });
-    await page.mouse.click(x, y);
-    // MapLibre の click→queryRenderedFeatures→setData は同期的なので wait は最小
-    await page.waitForTimeout(100);
-    const after = await page.evaluate(() => {
-      const g = window as unknown as {
-        __mlMap?: { getSource(id: string): unknown };
-      };
-      const src = g.__mlMap?.getSource("hidden-overlay") as
-        | { _data?: { features?: unknown[] } }
-        | undefined;
-      return src?._data?.features?.length ?? 0;
-    });
-    if (after > before) {
-      clicked = after;
-      break;
+    };
+    const m = g.__mlMap!;
+    const canvas = document.querySelector(".maplibregl-canvas") as HTMLElement;
+    const cw = canvas.clientWidth;
+    const ch = canvas.clientHeight;
+    const layers = [
+      "waterarea-fill",
+      "wstructurea-fill",
+      "river-line",
+      "railway-line",
+      "road-line",
+      "building-fill",
+      "boundary-line",
+    ];
+    const seen = new Map<string, [number, number]>();
+    for (let x = 40; x < cw && seen.size < 2; x += 30) {
+      for (let y = 40; y < ch && seen.size < 2; y += 30) {
+        const top = m.queryRenderedFeatures([x, y], { layers })[0];
+        if (!top) continue;
+        const key = JSON.stringify(top.geometry);
+        if (!seen.has(key)) seen.set(key, [x, y]);
+      }
     }
-  }
-  expect(clicked).toBeGreaterThan(0);
+    return [...seen.values()];
+  });
+  expect(hits.length).toBe(2);
+  const [p1, p2] = hits as [[number, number], [number, number]];
 
-  // リセットで空に戻る
-  await page.locator("#reset-edits").click();
-  const finalCount = await page.evaluate(() => {
+  // click payload を fire で流し込むヘルパ（shift 状態も込み）
+  async function fireClick(
+    pt: [number, number],
+    shift: boolean,
+  ): Promise<number> {
+    return page.evaluate(
+      ({ pt, shift }) => {
+        const g = window as unknown as {
+          __mlMap?: {
+            unproject(p: [number, number]): unknown;
+            fire(ev: string, payload: unknown): void;
+            getSource(id: string): unknown;
+          };
+        };
+        const m = g.__mlMap!;
+        const lngLat = m.unproject(pt);
+        m.fire("click", {
+          point: { x: pt[0], y: pt[1] },
+          lngLat,
+          originalEvent: new MouseEvent("click", { shiftKey: shift }),
+        });
+        const src = m.getSource("selection-overlay") as
+          | { _data?: { features?: unknown[] } }
+          | undefined;
+        return src?._data?.features?.length ?? 0;
+      },
+      { pt, shift },
+    );
+  }
+
+  // 1. p1 を click → 選択数 1
+  const n1 = await fireClick(p1, false);
+  expect(n1).toBe(1);
+
+  // 2. p2 を shift+click → 選択数 2
+  const n2 = await fireClick(p2, true);
+  expect(n2).toBe(2);
+
+  // 3. Esc で解除 → 0
+  await page.keyboard.press("Escape");
+  const final = await page.evaluate(() => {
     const g = window as unknown as { __mlMap?: { getSource(id: string): unknown } };
-    const src = g.__mlMap?.getSource("hidden-overlay") as
+    const src = g.__mlMap?.getSource("selection-overlay") as
       | { _data?: { features?: unknown[] } }
       | undefined;
     return src?._data?.features?.length ?? 0;
   });
-  expect(finalCount).toBe(0);
+  expect(final).toBe(0);
 });
 
 test("URL hash reflects view state after pan", async ({ page }) => {

--- a/tests/unit/selectionStore.test.ts
+++ b/tests/unit/selectionStore.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Geometry } from "geojson";
+import { SelectionStore, toSelectionFeatureCollection } from "../../src/state/selectionStore";
+
+function poly(coords: [number, number][]): Geometry {
+  return { type: "Polygon", coordinates: [coords] };
+}
+
+function line(coords: [number, number][]): Geometry {
+  return { type: "LineString", coordinates: coords };
+}
+
+const A = { sourceLayer: "building", geometry: poly([[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]), properties: { ftCode: 3101 } };
+const B = { sourceLayer: "building", geometry: poly([[10, 10], [11, 10], [11, 11], [10, 11], [10, 10]]), properties: { ftCode: 3101 } };
+const C = { sourceLayer: "road", geometry: line([[5, 5], [5, 6]]), properties: { ftCode: 2701 } };
+
+describe("SelectionStore", () => {
+  it("starts empty", () => {
+    const s = new SelectionStore();
+    expect(s.state).toEqual([]);
+  });
+
+  it("selectOne replaces the current selection (single-select)", () => {
+    const s = new SelectionStore();
+    s.selectOne(A);
+    expect(s.state).toHaveLength(1);
+    s.selectOne(B);
+    expect(s.state).toHaveLength(1);
+    expect(s.state[0]!.sourceLayer).toBe("building");
+    expect((s.state[0]!.geometry as { coordinates: unknown }).coordinates).toEqual(
+      (B.geometry as { coordinates: unknown }).coordinates,
+    );
+  });
+
+  it("add appends to the selection (multi-select)", () => {
+    const s = new SelectionStore();
+    s.add(A);
+    s.add(B);
+    s.add(C);
+    expect(s.state).toHaveLength(3);
+  });
+
+  it("add dedupes the same feature (same sourceLayer + geometry)", () => {
+    const s = new SelectionStore();
+    s.add(A);
+    s.add(A);
+    expect(s.state).toHaveLength(1);
+  });
+
+  it("toggle adds if absent and removes if present", () => {
+    const s = new SelectionStore();
+    s.toggle(A);
+    expect(s.state).toHaveLength(1);
+    s.toggle(A);
+    expect(s.state).toEqual([]);
+    s.toggle(A);
+    s.toggle(B);
+    expect(s.state).toHaveLength(2);
+    s.toggle(A);
+    expect(s.state).toHaveLength(1);
+    expect(s.state[0]!.geometry).toEqual(B.geometry);
+  });
+
+  it("clear empties the selection and fires listener once", () => {
+    const s = new SelectionStore();
+    s.add(A);
+    s.add(B);
+    const listener = vi.fn();
+    s.subscribe(listener);
+    s.clear();
+    expect(s.state).toEqual([]);
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it("clear is a no-op when already empty (no listener call)", () => {
+    const s = new SelectionStore();
+    const listener = vi.fn();
+    s.subscribe(listener);
+    s.clear();
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it("subscribe/unsubscribe", () => {
+    const s = new SelectionStore();
+    const l = vi.fn();
+    const off = s.subscribe(l);
+    s.selectOne(A);
+    expect(l).toHaveBeenCalledTimes(1);
+    off();
+    s.selectOne(B);
+    expect(l).toHaveBeenCalledTimes(1);
+  });
+
+  it("selectOne fires listener even when replacing (content changed)", () => {
+    const s = new SelectionStore();
+    s.selectOne(A);
+    const l = vi.fn();
+    s.subscribe(l);
+    s.selectOne(B);
+    expect(l).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("toSelectionFeatureCollection", () => {
+  it("returns empty FeatureCollection for empty selection", () => {
+    expect(toSelectionFeatureCollection([])).toEqual({ type: "FeatureCollection", features: [] });
+  });
+
+  it("serializes each entry with stable id and sourceLayer property", () => {
+    const s = new SelectionStore();
+    s.add(A);
+    s.add(C);
+    const fc = toSelectionFeatureCollection(s.state);
+    expect(fc.features).toHaveLength(2);
+    expect(fc.features[0]!.properties?._sourceLayer).toBe("building");
+    expect(fc.features[1]!.properties?._sourceLayer).toBe("road");
+  });
+});


### PR DESCRIPTION
## Summary
- 解釈Bに寄せて、click=select の選択モデル基盤を導入
- SelectionStore / selection overlay（橙 #ff8800 の縁取り）/ Esc で解除
- 「選択: N」カウンタをヘッダに表示
- #7 の「クリック=即時 hide」は撤回（#16 で削除アクションとして復活予定）

## 技術的な気づき
`map.queryRenderedFeatures(e.point, ...)` で `e.point` を `{x, y}` オブジェクトのまま渡すと、MapLibre 内部で **options として解釈され viewport 全体走査**（本実環境で 10,629 features）になる不具合に当たった。修正として `[x, y]` 配列形式に統一。

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test` — 35件 Green（selectionStore 11件新設）
- [x] `pnpm e2e` — 4件 Green
- [x] 実ブラウザで複数選択の橙縁取り／「選択: 2」カウンタ／Esc解除 を確認
- [x] プリセット切替で overlay が維持されることを確認

## Closes
Closes #15

## Refs
- #7 の click=hide 挙動を撤回
- 続く #16 (削除+Undo) / #17 (矩形選択) / #18 (スティッキーモード) / #19 (強調) / #9 (ラベル) はこの基盤に乗る
