### PR TITLE
feat: 削除アクション + Undo/Redo

### DIFF
--- a/index.html
+++ b/index.html
@@ -86,6 +86,10 @@
       .preset-group button[aria-pressed="true"]:hover {
         background: #222;
       }
+      .edit-group {
+        display: inline-flex;
+        gap: 6px;
+      }
       #map {
         width: 100%;
         height: 100%;
@@ -102,9 +106,14 @@
           <button id="preset-standard" type="button" aria-pressed="true">標準</button>
           <button id="preset-mono" type="button" aria-pressed="false">モノトーン</button>
         </div>
-        <button id="reset-edits" class="primary" type="button" title="非表示にした要素を全て戻す" disabled>
-          編集をリセット
-        </button>
+        <div class="edit-group" role="group" aria-label="編集アクション">
+          <button id="undo" class="primary" type="button" title="戻す (⌘Z)" disabled>戻す</button>
+          <button id="redo" class="primary" type="button" title="やり直す (⇧⌘Z)" disabled>やり直す</button>
+          <button id="delete" class="primary" type="button" title="選択中を削除 (Delete)" disabled>削除</button>
+          <button id="reset-edits" class="primary" type="button" title="編集を全て破棄" disabled>
+            編集をリセット
+          </button>
+        </div>
         <button id="export-png" class="primary" type="button">PNG書き出し</button>
       </header>
       <div id="map"></div>

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,8 +17,13 @@ import {
   encodeViewToHash,
   type ViewState,
 } from "./state/viewState";
-import { EditStateStore, toHiddenFeatureCollection } from "./state/editState";
+import {
+  EditStateStore,
+  toHiddenFeatureCollection,
+  type EditStateSnapshot,
+} from "./state/editState";
 import { SelectionStore, toSelectionFeatureCollection } from "./state/selectionStore";
+import { History } from "./state/history";
 import { buildExportFilename, composePngWithCredit, downloadCanvasAsPng } from "./export/png";
 
 function requireEl<T extends Element>(id: string, ctor: new (...a: never[]) => T): T {
@@ -31,6 +36,9 @@ const mapRoot = requireEl("map", HTMLElement);
 const exportButton = requireEl("export-png", HTMLButtonElement);
 const presetStandardBtn = requireEl("preset-standard", HTMLButtonElement);
 const presetMonoBtn = requireEl("preset-mono", HTMLButtonElement);
+const undoBtn = requireEl("undo", HTMLButtonElement);
+const redoBtn = requireEl("redo", HTMLButtonElement);
+const deleteBtn = requireEl("delete", HTMLButtonElement);
 const resetEditsBtn = requireEl("reset-edits", HTMLButtonElement);
 const selectionCountEl = requireEl("selection-count", HTMLSpanElement);
 
@@ -38,6 +46,7 @@ const initialView: ViewState = decodeHashToView(window.location.hash) ?? DEFAULT
 let currentPreset: Preset = "standard";
 const editState = new EditStateStore();
 const selectionStore = new SelectionStore();
+const history = new History<EditStateSnapshot>();
 
 const map: MapLibreMap = new maplibregl.Map({
   container: mapRoot,
@@ -88,38 +97,42 @@ map.on("styledata", () => {
   refreshOverlays();
 });
 
-// 編集状態が変わったら hidden overlay の data を更新。
 editState.subscribe((s) => {
   setHiddenOverlayData(map, toHiddenFeatureCollection(s.hidden));
   resetEditsBtn.disabled = s.hidden.length === 0;
 });
 resetEditsBtn.disabled = true;
 
-// 選択状態が変わったら selection overlay の data と選択数表示を更新。
 function updateSelectionUI(): void {
   const n = selectionStore.state.length;
   selectionCountEl.textContent = n > 0 ? `選択: ${n}` : "";
   setSelectionOverlayData(map, toSelectionFeatureCollection(selectionStore.state));
+  deleteBtn.disabled = n === 0;
 }
 selectionStore.subscribe(() => updateSelectionUI());
 updateSelectionUI();
+
+history.subscribe((status) => {
+  undoBtn.disabled = !status.canUndo;
+  redoBtn.disabled = !status.canRedo;
+});
 
 if (import.meta.env.DEV) {
   const w = globalThis as unknown as {
     __mlMap?: MapLibreMap;
     __editState?: EditStateStore;
     __selectionStore?: SelectionStore;
+    __history?: History<EditStateSnapshot>;
   };
   w.__mlMap = map;
   w.__editState = editState;
   w.__selectionStore = selectionStore;
+  w.__history = history;
 }
 
 function applyPreset(next: Preset): void {
   if (next === currentPreset) return;
   currentPreset = next;
-  // source と layer を差分更新で入れ替える。diff: true なら source(タイル)は再取得しない。
-  // setStyle → styledata が発火 → refreshOverlays() で overlay 再適用。
   map.setStyle(buildBaseStyle(next), { diff: true });
   presetStandardBtn.setAttribute("aria-pressed", String(next === "standard"));
   presetMonoBtn.setAttribute("aria-pressed", String(next === "mono"));
@@ -127,13 +140,7 @@ function applyPreset(next: Preset): void {
 presetStandardBtn.addEventListener("click", () => applyPreset("standard"));
 presetMonoBtn.addEventListener("click", () => applyPreset("mono"));
 
-// クリックで feature を選択。shift+click で toggle（追加/解除）。
-// 空所クリックは選択解除。
-//
-// queryRenderedFeatures の第1引数は PointLike（[x, y] or {x, y}）。
-// e.point は {x, y} オブジェクトだが、そのまま渡すと MapLibre 内部で
-// 「options」として解釈されて viewport 全体走査になるケースがある。
-// 明示的に [x, y] 配列化する。
+// 選択操作（click / shift+click / 空クリックで clear）
 map.on("click", (e) => {
   const pt: [number, number] = [e.point.x, e.point.y];
   const features = map.queryRenderedFeatures(pt, {
@@ -157,22 +164,87 @@ map.on("click", (e) => {
   }
 });
 
-// Hideable レイヤ上でポインタを指に変える（クリック可能性の示唆）。
 map.on("mousemove", (e) => {
   const pt: [number, number] = [e.point.x, e.point.y];
   const hit = map.queryRenderedFeatures(pt, { layers: [...HIDEABLE_LAYER_IDS] });
   map.getCanvas().style.cursor = hit.length > 0 ? "pointer" : "";
 });
 
-// Esc キーで選択解除。
+// ---- アクション ----
+
+function deleteSelected(): void {
+  const items = selectionStore.state;
+  if (items.length === 0) return;
+  const before = editState.snapshot();
+  editState.hideMany(
+    items.map((i) => ({
+      sourceLayer: i.sourceLayer,
+      geometry: i.geometry,
+      properties: i.properties,
+    })),
+  );
+  selectionStore.clear();
+  history.push(before);
+}
+
+function resetAllEdits(): void {
+  if (editState.state.hidden.length === 0) return;
+  const before = editState.snapshot();
+  editState.clearAll();
+  history.push(before);
+}
+
+function undo(): void {
+  const prev = history.undo(editState.snapshot());
+  if (prev) editState.restore(prev);
+}
+
+function redo(): void {
+  const next = history.redo(editState.snapshot());
+  if (next) editState.restore(next);
+}
+
+deleteBtn.addEventListener("click", deleteSelected);
+resetEditsBtn.addEventListener("click", resetAllEdits);
+undoBtn.addEventListener("click", undo);
+redoBtn.addEventListener("click", redo);
+
+// ---- キーボードショートカット ----
+
+function isTextEditable(el: EventTarget | null): boolean {
+  if (!(el instanceof HTMLElement)) return false;
+  if (el.isContentEditable) return true;
+  return el instanceof HTMLInputElement || el instanceof HTMLTextAreaElement;
+}
+
 window.addEventListener("keydown", (e) => {
+  if (isTextEditable(e.target)) return;
+
   if (e.key === "Escape") {
     selectionStore.clear();
+    return;
   }
-});
 
-resetEditsBtn.addEventListener("click", () => {
-  editState.clearAll();
+  if (e.key === "Delete" || e.key === "Backspace") {
+    if (selectionStore.state.length > 0) {
+      e.preventDefault();
+      deleteSelected();
+    }
+    return;
+  }
+
+  const meta = e.metaKey || e.ctrlKey;
+  if (meta && (e.key === "z" || e.key === "Z")) {
+    e.preventDefault();
+    if (e.shiftKey) redo();
+    else undo();
+    return;
+  }
+  if (meta && (e.key === "y" || e.key === "Y")) {
+    // Windows 流の Redo
+    e.preventDefault();
+    redo();
+  }
 });
 
 exportButton.addEventListener("click", async () => {

--- a/src/state/editState.ts
+++ b/src/state/editState.ts
@@ -26,7 +26,17 @@ export interface HideInput {
   properties: Record<string, unknown>;
 }
 
+/** Undo 履歴用の独立スナップショット。clone 保持。 */
+export interface EditStateSnapshot {
+  hidden: HiddenFeature[];
+  counter: number;
+}
+
 type Listener = (state: EditState) => void;
+
+function deepClone<T>(v: T): T {
+  return JSON.parse(JSON.stringify(v)) as T;
+}
 
 export class EditStateStore {
   private _hidden: HiddenFeature[] = [];
@@ -38,16 +48,19 @@ export class EditStateStore {
   }
 
   hide(input: HideInput): HiddenFeature {
-    this._counter += 1;
-    const entry: HiddenFeature = {
-      id: `h-${this._counter}`,
-      sourceLayer: input.sourceLayer,
-      geometry: input.geometry,
-      properties: { ...input.properties },
-    };
+    const entry = this._build(input);
     this._hidden.push(entry);
     this._emit();
     return entry;
+  }
+
+  /** 複数 feature を一括で非表示化。listener は 1 回だけ発火。 */
+  hideMany(inputs: ReadonlyArray<HideInput>): HiddenFeature[] {
+    if (inputs.length === 0) return [];
+    const entries = inputs.map((i) => this._build(i));
+    this._hidden.push(...entries);
+    this._emit();
+    return entries;
   }
 
   clearAll(): void {
@@ -56,10 +69,35 @@ export class EditStateStore {
     this._emit();
   }
 
+  /** 現在の状態のディープコピーを返す。Undo 履歴への投入用。 */
+  snapshot(): EditStateSnapshot {
+    return {
+      hidden: deepClone(this._hidden),
+      counter: this._counter,
+    };
+  }
+
+  /** snapshot で取った状態に復元。listener を 1 回発火。 */
+  restore(s: EditStateSnapshot): void {
+    this._hidden = deepClone(s.hidden);
+    this._counter = s.counter;
+    this._emit();
+  }
+
   subscribe(l: Listener): () => void {
     this._listeners.add(l);
     return () => {
       this._listeners.delete(l);
+    };
+  }
+
+  private _build(input: HideInput): HiddenFeature {
+    this._counter += 1;
+    return {
+      id: `h-${this._counter}`,
+      sourceLayer: input.sourceLayer,
+      geometry: input.geometry,
+      properties: { ...input.properties },
     };
   }
 

--- a/src/state/history.ts
+++ b/src/state/history.ts
@@ -1,0 +1,71 @@
+/**
+ * 汎用の Undo/Redo 履歴。snapshot ベース。
+ *
+ * 呼び出し側が push(snapshotBeforeAction) してから状態を変更。
+ * undo(current) は直前の snapshot を返し、current を redo スタックに積む。
+ * redo(current) は逆方向。
+ *
+ * 新しい push をすると redo スタックはクリアされる（典型的な undo 動作）。
+ */
+
+export interface HistoryStatus {
+  canUndo: boolean;
+  canRedo: boolean;
+}
+
+type Listener = (s: HistoryStatus) => void;
+
+export class History<T> {
+  private _undoStack: T[] = [];
+  private _redoStack: T[] = [];
+  private _listeners = new Set<Listener>();
+
+  get canUndo(): boolean {
+    return this._undoStack.length > 0;
+  }
+
+  get canRedo(): boolean {
+    return this._redoStack.length > 0;
+  }
+
+  push(snap: T): void {
+    this._undoStack.push(snap);
+    this._redoStack.length = 0;
+    this._emit();
+  }
+
+  undo(current: T): T | null {
+    const prev = this._undoStack.pop();
+    if (prev === undefined) return null;
+    this._redoStack.push(current);
+    this._emit();
+    return prev;
+  }
+
+  redo(current: T): T | null {
+    const next = this._redoStack.pop();
+    if (next === undefined) return null;
+    this._undoStack.push(current);
+    this._emit();
+    return next;
+  }
+
+  clear(): void {
+    if (this._undoStack.length === 0 && this._redoStack.length === 0) return;
+    this._undoStack.length = 0;
+    this._redoStack.length = 0;
+    this._emit();
+  }
+
+  subscribe(l: Listener): () => void {
+    this._listeners.add(l);
+    return () => {
+      this._listeners.delete(l);
+    };
+  }
+
+  private _emit(): void {
+    const s: HistoryStatus = { canUndo: this.canUndo, canRedo: this.canRedo };
+    for (const l of this._listeners) l(s);
+  }
+}

--- a/tests/e2e/display-and-export.spec.ts
+++ b/tests/e2e/display-and-export.spec.ts
@@ -200,6 +200,206 @@ test("clicking a feature selects it; shift+click adds; Esc clears", async ({ pag
   expect(final).toBe(0);
 });
 
+test("select → delete → undo → redo cycles the hidden overlay", async ({ page }) => {
+  await page.goto("/");
+  await page.waitForFunction(() => document.body.dataset.mapReady === "true", null, {
+    timeout: 30_000,
+  });
+
+  await page.evaluate(() => {
+    const g = window as unknown as { __mlMap?: { setZoom(z: number): void } };
+    g.__mlMap?.setZoom(15);
+  });
+  await page.waitForFunction(
+    () => {
+      const g = window as unknown as {
+        __mlMap?: {
+          getZoom(): number;
+          isStyleLoaded(): boolean;
+          areTilesLoaded(): boolean;
+        };
+      };
+      return (
+        !!g.__mlMap &&
+        Math.round(g.__mlMap.getZoom()) === 15 &&
+        g.__mlMap.isStyleLoaded() &&
+        g.__mlMap.areTilesLoaded()
+      );
+    },
+    null,
+    { timeout: 15_000 },
+  );
+
+  // 選択用に1点探す
+  const pt = await page.evaluate(() => {
+    const g = window as unknown as {
+      __mlMap?: {
+        queryRenderedFeatures(
+          p: [number, number],
+          opts?: { layers?: string[] },
+        ): Array<{ geometry: unknown }>;
+      };
+    };
+    const m = g.__mlMap!;
+    const canvas = document.querySelector(".maplibregl-canvas") as HTMLElement;
+    const cw = canvas.clientWidth;
+    const ch = canvas.clientHeight;
+    const layers = [
+      "waterarea-fill",
+      "wstructurea-fill",
+      "river-line",
+      "railway-line",
+      "road-line",
+      "building-fill",
+      "boundary-line",
+    ];
+    for (let x = 40; x < cw; x += 30) {
+      for (let y = 40; y < ch; y += 30) {
+        if (m.queryRenderedFeatures([x, y], { layers }).length > 0) return [x, y];
+      }
+    }
+    return null;
+  });
+  expect(pt).not.toBeNull();
+  const [x, y] = pt as [number, number];
+
+  // 選択
+  await page.evaluate(
+    ({ x, y }) => {
+      const g = window as unknown as {
+        __mlMap?: {
+          unproject(p: [number, number]): unknown;
+          fire(ev: string, payload: unknown): void;
+        };
+      };
+      const m = g.__mlMap!;
+      m.fire("click", {
+        point: { x, y },
+        lngLat: m.unproject([x, y]),
+        originalEvent: new MouseEvent("click"),
+      });
+    },
+    { x, y },
+  );
+
+  const hiddenCount = async (): Promise<number> =>
+    page.evaluate(() => {
+      const g = window as unknown as { __mlMap?: { getSource(id: string): unknown } };
+      const src = g.__mlMap?.getSource("hidden-overlay") as
+        | { _data?: { features?: unknown[] } }
+        | undefined;
+      return src?._data?.features?.length ?? 0;
+    });
+
+  // 削除ボタン → 非表示1件、selection は空、リセット/undo 有効
+  await page.locator("#delete").click();
+  expect(await hiddenCount()).toBe(1);
+  await expect(page.locator("#selection-count")).toHaveText("");
+  await expect(page.locator("#undo")).toBeEnabled();
+  await expect(page.locator("#redo")).toBeDisabled();
+
+  // Undo → 非表示0件、Redo 有効
+  await page.locator("#undo").click();
+  expect(await hiddenCount()).toBe(0);
+  await expect(page.locator("#redo")).toBeEnabled();
+  await expect(page.locator("#undo")).toBeDisabled();
+
+  // Redo → 非表示1件戻る
+  await page.locator("#redo").click();
+  expect(await hiddenCount()).toBe(1);
+  await expect(page.locator("#undo")).toBeEnabled();
+  await expect(page.locator("#redo")).toBeDisabled();
+});
+
+test("Delete key deletes selection; Cmd+Z undoes", async ({ page }) => {
+  await page.goto("/");
+  await page.waitForFunction(() => document.body.dataset.mapReady === "true", null, {
+    timeout: 30_000,
+  });
+  await page.evaluate(() => {
+    const g = window as unknown as { __mlMap?: { setZoom(z: number): void } };
+    g.__mlMap?.setZoom(15);
+  });
+  await page.waitForFunction(
+    () => {
+      const g = window as unknown as {
+        __mlMap?: { getZoom(): number; isStyleLoaded(): boolean; areTilesLoaded(): boolean };
+      };
+      return (
+        !!g.__mlMap &&
+        Math.round(g.__mlMap.getZoom()) === 15 &&
+        g.__mlMap.isStyleLoaded() &&
+        g.__mlMap.areTilesLoaded()
+      );
+    },
+    null,
+    { timeout: 15_000 },
+  );
+
+  // 選択＋削除（Delete キー経由）
+  const pt = await page.evaluate(() => {
+    const g = window as unknown as {
+      __mlMap?: {
+        queryRenderedFeatures(p: [number, number], opts?: { layers?: string[] }): Array<unknown>;
+      };
+    };
+    const m = g.__mlMap!;
+    const canvas = document.querySelector(".maplibregl-canvas") as HTMLElement;
+    for (let x = 40; x < canvas.clientWidth; x += 30) {
+      for (let y = 40; y < canvas.clientHeight; y += 30) {
+        if (
+          m.queryRenderedFeatures([x, y], {
+            layers: [
+              "waterarea-fill",
+              "wstructurea-fill",
+              "river-line",
+              "railway-line",
+              "road-line",
+              "building-fill",
+              "boundary-line",
+            ],
+          }).length > 0
+        )
+          return [x, y];
+      }
+    }
+    return null;
+  });
+  expect(pt).not.toBeNull();
+  const [x, y] = pt as [number, number];
+
+  await page.evaluate(
+    ({ x, y }) => {
+      const g = window as unknown as {
+        __mlMap?: { unproject(p: [number, number]): unknown; fire(ev: string, payload: unknown): void };
+      };
+      const m = g.__mlMap!;
+      m.fire("click", {
+        point: { x, y },
+        lngLat: m.unproject([x, y]),
+        originalEvent: new MouseEvent("click"),
+      });
+    },
+    { x, y },
+  );
+
+  const hidden = async (): Promise<number> =>
+    page.evaluate(() => {
+      const g = window as unknown as { __mlMap?: { getSource(id: string): unknown } };
+      const src = g.__mlMap?.getSource("hidden-overlay") as
+        | { _data?: { features?: unknown[] } }
+        | undefined;
+      return src?._data?.features?.length ?? 0;
+    });
+
+  await page.keyboard.press("Delete");
+  expect(await hidden()).toBe(1);
+
+  // Cmd+Z（Mac）/ Ctrl+Z（Linux/Windows）両方許容
+  await page.keyboard.press(process.platform === "darwin" ? "Meta+KeyZ" : "Control+KeyZ");
+  expect(await hidden()).toBe(0);
+});
+
 test("URL hash reflects view state after pan", async ({ page }) => {
   await page.goto("/");
   await page.waitForFunction(() => document.body.dataset.mapReady === "true", null, {

--- a/tests/unit/editState.test.ts
+++ b/tests/unit/editState.test.ts
@@ -76,6 +76,54 @@ describe("EditStateStore", () => {
     s.hide({ sourceLayer: "x", geometry: { type: "Point", coordinates: [0, 0] }, properties: {} });
     expect(listener).toHaveBeenCalledTimes(1);
   });
+
+  it("hideMany appends multiple features in a single listener call", () => {
+    const s = new EditStateStore();
+    const listener = vi.fn();
+    s.subscribe(listener);
+    const entries = s.hideMany([
+      { sourceLayer: "road", geometry: { type: "Point", coordinates: [0, 0] }, properties: {} },
+      { sourceLayer: "road", geometry: { type: "Point", coordinates: [1, 1] }, properties: {} },
+      { sourceLayer: "building", geometry: { type: "Point", coordinates: [2, 2] }, properties: {} },
+    ]);
+    expect(entries).toHaveLength(3);
+    expect(s.state.hidden).toHaveLength(3);
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it("hideMany with empty array does not fire listener", () => {
+    const s = new EditStateStore();
+    const listener = vi.fn();
+    s.subscribe(listener);
+    s.hideMany([]);
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it("snapshot + restore roundtrips the hidden list", () => {
+    const s = new EditStateStore();
+    s.hide({ sourceLayer: "road", geometry: { type: "Point", coordinates: [0, 0] }, properties: { a: 1 } });
+    s.hide({ sourceLayer: "building", geometry: { type: "Point", coordinates: [5, 5] }, properties: {} });
+    const snap = s.snapshot();
+
+    s.clearAll();
+    expect(s.state.hidden).toEqual([]);
+
+    const listener = vi.fn();
+    s.subscribe(listener);
+    s.restore(snap);
+    expect(s.state.hidden).toHaveLength(2);
+    expect(s.state.hidden[0]!.sourceLayer).toBe("road");
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it("snapshot is independent of subsequent mutations (deep-copied)", () => {
+    const s = new EditStateStore();
+    s.hide({ sourceLayer: "road", geometry: { type: "Point", coordinates: [0, 0] }, properties: {} });
+    const snap = s.snapshot();
+    s.hide({ sourceLayer: "road", geometry: { type: "Point", coordinates: [1, 1] }, properties: {} });
+    expect(snap.hidden).toHaveLength(1);
+    expect(s.state.hidden).toHaveLength(2);
+  });
 });
 
 describe("toHiddenFeatureCollection", () => {

--- a/tests/unit/history.test.ts
+++ b/tests/unit/history.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi } from "vitest";
+import { History } from "../../src/state/history";
+
+describe("History<T>", () => {
+  it("starts with no undo/redo available", () => {
+    const h = new History<number>();
+    expect(h.canUndo).toBe(false);
+    expect(h.canRedo).toBe(false);
+  });
+
+  it("push enables undo and clears redo", () => {
+    const h = new History<number>();
+    h.push(1);
+    expect(h.canUndo).toBe(true);
+    expect(h.canRedo).toBe(false);
+    // Do an undo to put something in redo stack, then push again: redo should clear
+    const prev = h.undo(2);
+    expect(prev).toBe(1);
+    expect(h.canRedo).toBe(true);
+    h.push(99);
+    expect(h.canRedo).toBe(false);
+  });
+
+  it("undo returns the last pushed snapshot and moves current to redo stack", () => {
+    const h = new History<string>();
+    h.push("a");
+    h.push("b");
+    expect(h.undo("current")).toBe("b");
+    expect(h.canUndo).toBe(true);
+    expect(h.canRedo).toBe(true);
+    expect(h.undo("was_b")).toBe("a");
+    expect(h.canUndo).toBe(false);
+  });
+
+  it("undo returns null when stack is empty", () => {
+    const h = new History<number>();
+    expect(h.undo(0)).toBeNull();
+  });
+
+  it("redo returns the last undone snapshot and moves current to undo stack", () => {
+    const h = new History<number>();
+    h.push(1);
+    h.push(2);
+    h.undo(3); // undo to 2, current=3 pushed to redo
+    h.undo(2); // undo to 1, current=2 pushed to redo
+    expect(h.canUndo).toBe(false);
+    expect(h.redo(1)).toBe(2);
+    expect(h.canUndo).toBe(true);
+    expect(h.redo(2)).toBe(3);
+    expect(h.canRedo).toBe(false);
+  });
+
+  it("redo returns null when stack is empty", () => {
+    const h = new History<number>();
+    expect(h.redo(0)).toBeNull();
+  });
+
+  it("subscribe fires on push/undo/redo with canUndo/canRedo snapshot", () => {
+    const h = new History<number>();
+    const listener = vi.fn();
+    h.subscribe(listener);
+    h.push(1);
+    expect(listener).toHaveBeenLastCalledWith({ canUndo: true, canRedo: false });
+    h.undo(2);
+    expect(listener).toHaveBeenLastCalledWith({ canUndo: false, canRedo: true });
+    h.redo(1);
+    expect(listener).toHaveBeenLastCalledWith({ canUndo: true, canRedo: false });
+  });
+
+  it("subscribe returns unsubscribe function", () => {
+    const h = new History<number>();
+    const l = vi.fn();
+    const off = h.subscribe(l);
+    h.push(1);
+    expect(l).toHaveBeenCalledTimes(1);
+    off();
+    h.push(2);
+    expect(l).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- 削除アクション（ボタン / Delete / Backspace）、選択中を一括 hide
- Undo/Redo（ボタン / Cmd+Z / Cmd+Shift+Z / Ctrl+Z / Ctrl+Y）
- 「編集をリセット」も undo 可能
- ヘッダに「戻す」「やり直す」「削除」ボタン追加

## 設計
- `History<T>` 汎用履歴（snapshot-based、push で redo クリア）
- `EditStateStore` に `hideMany` / `snapshot` / `restore` 追加
- 選択→アクション→ history.push の順でディープコピー保存 → undo で deep-restore

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test` — 55件 Green（history 8件・editState +4件・selectionStore 11件）
- [x] `pnpm e2e` — 6件 Green（select→delete→undo→redo、Delete/Cmd+Z）
- [x] ブラウザ実機で 2 feature 選択→削除→undo→redo を確認

## Closes
Closes #16
