### PR TITLE
feat: ハイライトアクション（選択中の feature を強調／解除）

### DIFF
--- a/index.html
+++ b/index.html
@@ -109,6 +109,7 @@
         <div class="edit-group" role="group" aria-label="編集アクション">
           <button id="undo" class="primary" type="button" title="戻す (⌘Z)" disabled>戻す</button>
           <button id="redo" class="primary" type="button" title="やり直す (⇧⌘Z)" disabled>やり直す</button>
+          <button id="highlight" class="primary" type="button" title="選択中を強調／解除" disabled>強調</button>
           <button id="delete" class="primary" type="button" title="選択中を削除 (Delete)" disabled>削除</button>
           <button id="reset-edits" class="primary" type="button" title="編集を全て破棄" disabled>
             編集をリセット

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,6 +12,10 @@ import {
   setSelectionOverlayData,
 } from "./map/selectionOverlay";
 import {
+  ensureHighlightOverlay,
+  setHighlightOverlayData,
+} from "./map/highlightOverlay";
+import {
   DEFAULT_VIEW,
   decodeHashToView,
   encodeViewToHash,
@@ -20,6 +24,7 @@ import {
 import {
   EditStateStore,
   toHiddenFeatureCollection,
+  toHighlightFeatureCollection,
   type EditStateSnapshot,
 } from "./state/editState";
 import { SelectionStore, toSelectionFeatureCollection } from "./state/selectionStore";
@@ -38,6 +43,7 @@ const presetStandardBtn = requireEl("preset-standard", HTMLButtonElement);
 const presetMonoBtn = requireEl("preset-mono", HTMLButtonElement);
 const undoBtn = requireEl("undo", HTMLButtonElement);
 const redoBtn = requireEl("redo", HTMLButtonElement);
+const highlightBtn = requireEl("highlight", HTMLButtonElement);
 const deleteBtn = requireEl("delete", HTMLButtonElement);
 const resetEditsBtn = requireEl("reset-edits", HTMLButtonElement);
 const selectionCountEl = requireEl("selection-count", HTMLSpanElement);
@@ -80,6 +86,11 @@ map.on("moveend", syncHash);
 map.on("zoomend", syncHash);
 
 function refreshOverlays(): void {
+  // 描画順（下 → 上）：base → highlight → hidden mask → selection stroke。
+  // 先に addLayer した方が下に入るので、呼び出し順は highlight → hidden → selection。
+  // すでに layer がある 2 回目以降は ensure*Overlay が paint/data を更新するのみで、
+  // layer 順序は最初の呼び出し順で固定される。
+  ensureHighlightOverlay(map, toHighlightFeatureCollection(editState.state.highlighted));
   ensureHiddenOverlay(map, currentPreset, toHiddenFeatureCollection(editState.state.hidden));
   ensureSelectionOverlay(map, toSelectionFeatureCollection(selectionStore.state));
 }
@@ -99,7 +110,8 @@ map.on("styledata", () => {
 
 editState.subscribe((s) => {
   setHiddenOverlayData(map, toHiddenFeatureCollection(s.hidden));
-  resetEditsBtn.disabled = s.hidden.length === 0;
+  setHighlightOverlayData(map, toHighlightFeatureCollection(s.highlighted));
+  resetEditsBtn.disabled = s.hidden.length === 0 && s.highlighted.length === 0;
 });
 resetEditsBtn.disabled = true;
 
@@ -108,6 +120,7 @@ function updateSelectionUI(): void {
   selectionCountEl.textContent = n > 0 ? `選択: ${n}` : "";
   setSelectionOverlayData(map, toSelectionFeatureCollection(selectionStore.state));
   deleteBtn.disabled = n === 0;
+  highlightBtn.disabled = n === 0;
 }
 selectionStore.subscribe(() => updateSelectionUI());
 updateSelectionUI();
@@ -187,8 +200,25 @@ function deleteSelected(): void {
   history.push(before);
 }
 
+// 選択中の全 feature に強調を適用。すでに全員強調されている場合は解除。
+// 混在時（一部強調・一部未強調）は「未強調のものを全て強調」で揃える。
+function toggleHighlightSelected(): void {
+  const items = selectionStore.state;
+  if (items.length === 0) return;
+  const before = editState.snapshot();
+  const allHighlighted = items.every((i) => editState.isHighlighted(i));
+  if (allHighlighted) {
+    editState.unhighlightMatching(items);
+  } else {
+    const missing = items.filter((i) => !editState.isHighlighted(i));
+    editState.highlightMany(missing);
+  }
+  history.push(before);
+}
+
 function resetAllEdits(): void {
-  if (editState.state.hidden.length === 0) return;
+  const s = editState.state;
+  if (s.hidden.length === 0 && s.highlighted.length === 0) return;
   const before = editState.snapshot();
   editState.clearAll();
   history.push(before);
@@ -205,6 +235,7 @@ function redo(): void {
 }
 
 deleteBtn.addEventListener("click", deleteSelected);
+highlightBtn.addEventListener("click", toggleHighlightSelected);
 resetEditsBtn.addEventListener("click", resetAllEdits);
 undoBtn.addEventListener("click", undo);
 redoBtn.addEventListener("click", redo);

--- a/src/map/highlightOverlay.ts
+++ b/src/map/highlightOverlay.ts
@@ -1,0 +1,87 @@
+import type { FeatureCollection } from "geojson";
+import type { GeoJSONSource, Map as MapLibreMap } from "maplibre-gl";
+
+/**
+ * 強調中 feature の視覚表現。preset 非依存の固定色 (#d93b3b)。
+ *
+ * 塗り＋縁取りで「強調されている」ことが紙面でも判る強度を出す。
+ * hidden-overlay より下に描画することで、非表示にした feature の
+ * 強調は bg mask に覆われて見えなくなる（=「消された物は消えたまま」）。
+ */
+
+export const HIGHLIGHT_SOURCE_ID = "highlight-overlay";
+export const HIGHLIGHT_LAYER_IDS = {
+  polygonFill: "highlight-polygon-fill",
+  polygonStroke: "highlight-polygon-stroke",
+  line: "highlight-line",
+  point: "highlight-point",
+} as const;
+
+export const HIGHLIGHT_COLOR = "#d93b3b";
+
+export function ensureHighlightOverlay(map: MapLibreMap, data: FeatureCollection): void {
+  if (!map.getSource(HIGHLIGHT_SOURCE_ID)) {
+    map.addSource(HIGHLIGHT_SOURCE_ID, { type: "geojson", data });
+  } else {
+    (map.getSource(HIGHLIGHT_SOURCE_ID) as GeoJSONSource).setData(data);
+  }
+
+  // polygon: 赤の半透明塗り
+  if (!map.getLayer(HIGHLIGHT_LAYER_IDS.polygonFill)) {
+    map.addLayer({
+      id: HIGHLIGHT_LAYER_IDS.polygonFill,
+      type: "fill",
+      source: HIGHLIGHT_SOURCE_ID,
+      filter: ["==", ["geometry-type"], "Polygon"],
+      paint: {
+        "fill-color": HIGHLIGHT_COLOR,
+        "fill-opacity": 0.35,
+      },
+    });
+  }
+  // polygon: 赤の縁取り
+  if (!map.getLayer(HIGHLIGHT_LAYER_IDS.polygonStroke)) {
+    map.addLayer({
+      id: HIGHLIGHT_LAYER_IDS.polygonStroke,
+      type: "line",
+      source: HIGHLIGHT_SOURCE_ID,
+      filter: ["==", ["geometry-type"], "Polygon"],
+      paint: {
+        "line-color": HIGHLIGHT_COLOR,
+        "line-width": 2,
+      },
+    });
+  }
+  if (!map.getLayer(HIGHLIGHT_LAYER_IDS.line)) {
+    map.addLayer({
+      id: HIGHLIGHT_LAYER_IDS.line,
+      type: "line",
+      source: HIGHLIGHT_SOURCE_ID,
+      filter: ["==", ["geometry-type"], "LineString"],
+      paint: {
+        "line-color": HIGHLIGHT_COLOR,
+        "line-width": 5,
+        "line-opacity": 0.9,
+      },
+    });
+  }
+  if (!map.getLayer(HIGHLIGHT_LAYER_IDS.point)) {
+    map.addLayer({
+      id: HIGHLIGHT_LAYER_IDS.point,
+      type: "circle",
+      source: HIGHLIGHT_SOURCE_ID,
+      filter: ["==", ["geometry-type"], "Point"],
+      paint: {
+        "circle-color": HIGHLIGHT_COLOR,
+        "circle-radius": 8,
+      },
+    });
+  }
+}
+
+export function setHighlightOverlayData(map: MapLibreMap, data: FeatureCollection): void {
+  const src = map.getSource(HIGHLIGHT_SOURCE_ID);
+  if (src && "setData" in src) {
+    (src as GeoJSONSource).setData(data);
+  }
+}

--- a/src/state/editState.ts
+++ b/src/state/editState.ts
@@ -1,13 +1,11 @@
 import type { FeatureCollection, Geometry } from "geojson";
 
 /**
- * 非表示にされた feature の記録。
+ * 編集状態。hidden（非表示）と highlighted（強調）の 2 つのリストを持つ。
  *
- * GSI ベクトルタイルには feature.id が付与されていないため、`setFeatureState` による
- * per-feature hide は使えない。代わりに client-side で geometry を保持し、
- * 同色 mask layer のオーバレイで「消す」戦略を取る（#7）。
- *
- * `id` はこのセッション内で一意の合成値で、永続化や同期用ではない（#5 で扱う）。
+ * GSI ベクトルタイルには feature.id が付与されていないため、feature の
+ * 同一性は sourceLayer + geometry(JSON) の deep-equal で判定する。
+ * id はセッション内で一意の合成値（永続化用ではない）。
  */
 export interface HiddenFeature {
   id: string;
@@ -16,8 +14,16 @@ export interface HiddenFeature {
   properties: Record<string, unknown>;
 }
 
+export interface HighlightedFeature {
+  id: string;
+  sourceLayer: string;
+  geometry: Geometry;
+  properties: Record<string, unknown>;
+}
+
 export interface EditState {
   hidden: ReadonlyArray<HiddenFeature>;
+  highlighted: ReadonlyArray<HighlightedFeature>;
 }
 
 export interface HideInput {
@@ -26,10 +32,14 @@ export interface HideInput {
   properties: Record<string, unknown>;
 }
 
+export type HighlightInput = HideInput;
+
 /** Undo 履歴用の独立スナップショット。clone 保持。 */
 export interface EditStateSnapshot {
   hidden: HiddenFeature[];
+  highlighted: HighlightedFeature[];
   counter: number;
+  highlightCounter: number;
 }
 
 type Listener = (state: EditState) => void;
@@ -38,51 +48,90 @@ function deepClone<T>(v: T): T {
   return JSON.parse(JSON.stringify(v)) as T;
 }
 
+function keyOf(f: { sourceLayer: string; geometry: Geometry }): string {
+  return `${f.sourceLayer}::${JSON.stringify(f.geometry)}`;
+}
+
 export class EditStateStore {
   private _hidden: HiddenFeature[] = [];
+  private _highlighted: HighlightedFeature[] = [];
   private _listeners = new Set<Listener>();
   private _counter = 0;
+  private _highlightCounter = 0;
 
   get state(): EditState {
-    return { hidden: [...this._hidden] };
+    return { hidden: [...this._hidden], highlighted: [...this._highlighted] };
   }
 
+  // --- hide ---
+
   hide(input: HideInput): HiddenFeature {
-    const entry = this._build(input);
+    const entry = this._buildHidden(input);
     this._hidden.push(entry);
     this._emit();
     return entry;
   }
 
-  /** 複数 feature を一括で非表示化。listener は 1 回だけ発火。 */
   hideMany(inputs: ReadonlyArray<HideInput>): HiddenFeature[] {
     if (inputs.length === 0) return [];
-    const entries = inputs.map((i) => this._build(i));
+    const entries = inputs.map((i) => this._buildHidden(i));
     this._hidden.push(...entries);
     this._emit();
     return entries;
   }
 
   clearAll(): void {
-    if (this._hidden.length === 0) return;
+    if (this._hidden.length === 0 && this._highlighted.length === 0) return;
     this._hidden.length = 0;
+    this._highlighted.length = 0;
     this._emit();
   }
 
-  /** 現在の状態のディープコピーを返す。Undo 履歴への投入用。 */
+  // --- highlight ---
+
+  /** 複数 feature を強調。listener は 1 回だけ発火。 */
+  highlightMany(inputs: ReadonlyArray<HighlightInput>): HighlightedFeature[] {
+    if (inputs.length === 0) return [];
+    const entries = inputs.map((i) => this._buildHighlight(i));
+    this._highlighted.push(...entries);
+    this._emit();
+    return entries;
+  }
+
+  /** geometry match で強調解除。1 件以上マッチした場合のみ listener 発火。 */
+  unhighlightMatching(inputs: ReadonlyArray<HighlightInput>): void {
+    if (inputs.length === 0) return;
+    const keys = new Set(inputs.map(keyOf));
+    const before = this._highlighted.length;
+    this._highlighted = this._highlighted.filter((h) => !keys.has(keyOf(h)));
+    if (this._highlighted.length !== before) this._emit();
+  }
+
+  isHighlighted(input: HighlightInput): boolean {
+    const k = keyOf(input);
+    return this._highlighted.some((h) => keyOf(h) === k);
+  }
+
+  // --- snapshot ---
+
   snapshot(): EditStateSnapshot {
     return {
       hidden: deepClone(this._hidden),
+      highlighted: deepClone(this._highlighted),
       counter: this._counter,
+      highlightCounter: this._highlightCounter,
     };
   }
 
-  /** snapshot で取った状態に復元。listener を 1 回発火。 */
   restore(s: EditStateSnapshot): void {
     this._hidden = deepClone(s.hidden);
+    this._highlighted = deepClone(s.highlighted);
     this._counter = s.counter;
+    this._highlightCounter = s.highlightCounter;
     this._emit();
   }
+
+  // --- subscribe ---
 
   subscribe(l: Listener): () => void {
     this._listeners.add(l);
@@ -91,10 +140,20 @@ export class EditStateStore {
     };
   }
 
-  private _build(input: HideInput): HiddenFeature {
+  private _buildHidden(input: HideInput): HiddenFeature {
     this._counter += 1;
     return {
       id: `h-${this._counter}`,
+      sourceLayer: input.sourceLayer,
+      geometry: input.geometry,
+      properties: { ...input.properties },
+    };
+  }
+
+  private _buildHighlight(input: HighlightInput): HighlightedFeature {
+    this._highlightCounter += 1;
+    return {
+      id: `hl-${this._highlightCounter}`,
       sourceLayer: input.sourceLayer,
       geometry: input.geometry,
       properties: { ...input.properties },
@@ -109,13 +168,26 @@ export class EditStateStore {
 
 /**
  * 非表示リストを MapLibre の GeoJSON source 用 FeatureCollection に変換。
- *
- * `properties._sourceLayer` は mask 用 style 側で元レイヤ判定に使える予備情報。
- * `id` は FeatureCollection 側の feature.id としても入れておき、
- * setData 後に `map.querySourceFeatures` で辿れるようにする。
  */
 export function toHiddenFeatureCollection(
   list: ReadonlyArray<HiddenFeature>,
+): FeatureCollection {
+  return {
+    type: "FeatureCollection",
+    features: list.map((h) => ({
+      type: "Feature",
+      id: h.id,
+      geometry: h.geometry,
+      properties: {
+        _id: h.id,
+        _sourceLayer: h.sourceLayer,
+      },
+    })),
+  };
+}
+
+export function toHighlightFeatureCollection(
+  list: ReadonlyArray<HighlightedFeature>,
 ): FeatureCollection {
   return {
     type: "FeatureCollection",

--- a/tests/e2e/display-and-export.spec.ts
+++ b/tests/e2e/display-and-export.spec.ts
@@ -400,6 +400,114 @@ test("Delete key deletes selection; Cmd+Z undoes", async ({ page }) => {
   expect(await hidden()).toBe(0);
 });
 
+test("select → 強調 → toggle off → undo restores", async ({ page }) => {
+  await page.goto("/");
+  await page.waitForFunction(() => document.body.dataset.mapReady === "true", null, {
+    timeout: 30_000,
+  });
+  await page.evaluate(() => {
+    const g = window as unknown as { __mlMap?: { setZoom(z: number): void } };
+    g.__mlMap?.setZoom(15);
+  });
+  await page.waitForFunction(
+    () => {
+      const g = window as unknown as {
+        __mlMap?: { getZoom(): number; isStyleLoaded(): boolean; areTilesLoaded(): boolean };
+      };
+      return (
+        !!g.__mlMap &&
+        Math.round(g.__mlMap.getZoom()) === 15 &&
+        g.__mlMap.isStyleLoaded() &&
+        g.__mlMap.areTilesLoaded()
+      );
+    },
+    null,
+    { timeout: 15_000 },
+  );
+
+  const pt = await page.evaluate(() => {
+    const g = window as unknown as {
+      __mlMap?: {
+        queryRenderedFeatures(p: [number, number], opts?: { layers?: string[] }): Array<unknown>;
+      };
+    };
+    const m = g.__mlMap!;
+    const canvas = document.querySelector(".maplibregl-canvas") as HTMLElement;
+    for (let x = 40; x < canvas.clientWidth; x += 30) {
+      for (let y = 40; y < canvas.clientHeight; y += 30) {
+        if (
+          m.queryRenderedFeatures([x, y], {
+            layers: [
+              "waterarea-fill",
+              "wstructurea-fill",
+              "river-line",
+              "railway-line",
+              "road-line",
+              "building-fill",
+              "boundary-line",
+            ],
+          }).length > 0
+        )
+          return [x, y];
+      }
+    }
+    return null;
+  });
+  expect(pt).not.toBeNull();
+  const [x, y] = pt as [number, number];
+
+  await page.evaluate(
+    ({ x, y }) => {
+      const g = window as unknown as {
+        __mlMap?: { unproject(p: [number, number]): unknown; fire(ev: string, payload: unknown): void };
+      };
+      const m = g.__mlMap!;
+      m.fire("click", {
+        point: { x, y },
+        lngLat: m.unproject([x, y]),
+        originalEvent: new MouseEvent("click"),
+      });
+    },
+    { x, y },
+  );
+
+  const highlightCount = async (): Promise<number> =>
+    page.evaluate(() => {
+      const g = window as unknown as { __mlMap?: { getSource(id: string): unknown } };
+      const src = g.__mlMap?.getSource("highlight-overlay") as
+        | { _data?: { features?: unknown[] } }
+        | undefined;
+      return src?._data?.features?.length ?? 0;
+    });
+
+  // 強調 → 1件
+  await page.locator("#highlight").click();
+  expect(await highlightCount()).toBe(1);
+  await expect(page.locator("#undo")).toBeEnabled();
+
+  // 再選択して強調 → 0件（toggle off）
+  await page.evaluate(
+    ({ x, y }) => {
+      const g = window as unknown as {
+        __mlMap?: { unproject(p: [number, number]): unknown; fire(ev: string, payload: unknown): void };
+      };
+      const m = g.__mlMap!;
+      m.fire("click", {
+        point: { x, y },
+        lngLat: m.unproject([x, y]),
+        originalEvent: new MouseEvent("click"),
+      });
+    },
+    { x, y },
+  );
+  await page.locator("#highlight").click();
+  expect(await highlightCount()).toBe(0);
+
+  // Undo → 1件戻る
+  await page.locator("#undo").click();
+  expect(await highlightCount()).toBe(1);
+});
+
 test("URL hash reflects view state after pan", async ({ page }) => {
   await page.goto("/");
   await page.waitForFunction(() => document.body.dataset.mapReady === "true", null, {

--- a/tests/unit/editState.test.ts
+++ b/tests/unit/editState.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
 import type { Feature, LineString, Polygon } from "geojson";
-import { EditStateStore, toHiddenFeatureCollection } from "../../src/state/editState";
+import {
+  EditStateStore,
+  toHiddenFeatureCollection,
+  toHighlightFeatureCollection,
+} from "../../src/state/editState";
 
 function lineFeature(coords: [number, number][]): Feature<LineString> {
   return {
@@ -123,6 +127,97 @@ describe("EditStateStore", () => {
     s.hide({ sourceLayer: "road", geometry: { type: "Point", coordinates: [1, 1] }, properties: {} });
     expect(snap.hidden).toHaveLength(1);
     expect(s.state.hidden).toHaveLength(2);
+  });
+});
+
+describe("EditStateStore highlight", () => {
+  const featA = {
+    sourceLayer: "building",
+    geometry: { type: "Polygon" as const, coordinates: [[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]] },
+    properties: {},
+  };
+  const featB = {
+    sourceLayer: "road",
+    geometry: { type: "LineString" as const, coordinates: [[10, 10], [11, 11]] },
+    properties: {},
+  };
+
+  it("starts with empty highlighted list", () => {
+    const s = new EditStateStore();
+    expect(s.state.highlighted).toEqual([]);
+  });
+
+  it("highlightMany appends entries with h-prefixed ids", () => {
+    const s = new EditStateStore();
+    const entries = s.highlightMany([featA, featB]);
+    expect(entries).toHaveLength(2);
+    expect(entries[0]!.id).toMatch(/^hl-\d+$/);
+    expect(s.state.highlighted).toHaveLength(2);
+  });
+
+  it("isHighlighted matches by sourceLayer + geometry (deep-equal)", () => {
+    const s = new EditStateStore();
+    s.highlightMany([featA]);
+    expect(s.isHighlighted(featA)).toBe(true);
+    // Same geometry, different sourceLayer → not highlighted
+    expect(s.isHighlighted({ ...featA, sourceLayer: "road" })).toBe(false);
+    expect(s.isHighlighted(featB)).toBe(false);
+  });
+
+  it("unhighlightMatching removes by geometry match", () => {
+    const s = new EditStateStore();
+    s.highlightMany([featA, featB]);
+    s.unhighlightMatching([featA]);
+    expect(s.state.highlighted).toHaveLength(1);
+    expect(s.isHighlighted(featA)).toBe(false);
+    expect(s.isHighlighted(featB)).toBe(true);
+  });
+
+  it("snapshot + restore preserves highlighted list too", () => {
+    const s = new EditStateStore();
+    s.hide({ sourceLayer: "road", geometry: { type: "Point", coordinates: [0, 0] }, properties: {} });
+    s.highlightMany([featA, featB]);
+    const snap = s.snapshot();
+    s.unhighlightMatching([featA, featB]);
+    s.clearAll();
+    expect(s.state.hidden).toEqual([]);
+    expect(s.state.highlighted).toEqual([]);
+    s.restore(snap);
+    expect(s.state.hidden).toHaveLength(1);
+    expect(s.state.highlighted).toHaveLength(2);
+  });
+
+  it("highlightMany with empty array does not fire listener", () => {
+    const s = new EditStateStore();
+    const l = vi.fn();
+    s.subscribe(l);
+    s.highlightMany([]);
+    expect(l).not.toHaveBeenCalled();
+  });
+
+  it("unhighlightMatching no-match does not fire listener", () => {
+    const s = new EditStateStore();
+    const l = vi.fn();
+    s.subscribe(l);
+    s.unhighlightMatching([featA]);
+    expect(l).not.toHaveBeenCalled();
+  });
+});
+
+describe("toHighlightFeatureCollection", () => {
+  it("serializes highlighted entries like hidden ones", () => {
+    const s = new EditStateStore();
+    const [a] = s.highlightMany([
+      {
+        sourceLayer: "building",
+        geometry: { type: "Polygon", coordinates: [[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]] },
+        properties: {},
+      },
+    ]);
+    const fc = toHighlightFeatureCollection(s.state.highlighted);
+    expect(fc.features).toHaveLength(1);
+    expect(fc.features[0]!.id).toBe(a!.id);
+    expect(fc.features[0]!.properties?._sourceLayer).toBe("building");
   });
 });
 


### PR DESCRIPTION
## Summary
- 選択中の feature を強調（赤 #d93b3b）／解除
- ボタン一発でトグル：選択全部が既に強調なら解除、そうでなければ揃えて強調
- Undo/Redo 対応（#16 の履歴に乗る）
- PNG 書き出しにも反映

## 設計
- `EditState.highlighted: HighlightedFeature[]` を追加、scope は hidden と並列
- Snapshot/restore に組み込み（Undo で両方戻る）
- overlay 色は preset 非依存の固定値
- layer 順: `highlight → hidden mask → selection`
  - hidden mask は highlight の上に乗る（＝削除した feature が赤のまま残らない）
  - selection stroke は全部の上（選択状態を常に視認できる）

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test` — 55件 Green（editState +8件）
- [x] `pnpm e2e` — 7件 Green（強調 toggle + undo を新規検証）
- [x] ブラウザ実機で 3 feature（waterarea×2 + road line）強調→表示確認

## Closes
Closes #19
