### PR TITLE
feat: Shift+ドラッグで矩形選択（ラバーバンド）

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -15,6 +15,7 @@ import {
   ensureHighlightOverlay,
   setHighlightOverlayData,
 } from "./map/highlightOverlay";
+import { attachRubberBand } from "./map/rubberBand";
 import {
   DEFAULT_VIEW,
   decodeHashToView,
@@ -63,6 +64,10 @@ const map: MapLibreMap = new maplibregl.Map({
   attributionControl: false,
   preserveDrawingBuffer: true,
 });
+
+// MapLibre デフォルトの shift+drag = box zoom と衝突するので無効化。
+// shift+drag は本アプリではラバーバンド選択（#17）に割り当てる。
+map.boxZoom.disable();
 
 map.addControl(
   new maplibregl.AttributionControl({ compact: true, customAttribution: GSI_ATTRIBUTION }),
@@ -181,6 +186,24 @@ map.on("mousemove", (e) => {
   const pt: [number, number] = [e.point.x, e.point.y];
   const hit = map.queryRenderedFeatures(pt, { layers: [...HIDEABLE_LAYER_IDS] });
   map.getCanvas().style.cursor = hit.length > 0 ? "pointer" : "";
+});
+
+// Shift+ドラッグで矩形選択（既存選択に追加）。
+attachRubberBand(map, {
+  onRelease: (bbox) => {
+    const features = map.queryRenderedFeatures(bbox, {
+      layers: [...HIDEABLE_LAYER_IDS],
+    });
+    // 同一 feature が複数レイヤ／タイル境界で重複して返る可能性がある。
+    // SelectionStore.add が sourceLayer+geometry で重複排除するため add で流し込む。
+    for (const f of features) {
+      selectionStore.add({
+        sourceLayer: f.sourceLayer ?? "",
+        geometry: f.geometry,
+        properties: f.properties ?? {},
+      });
+    }
+  },
 });
 
 // ---- アクション ----

--- a/src/map/rubberBand.ts
+++ b/src/map/rubberBand.ts
@@ -1,0 +1,108 @@
+import type { Map as MapLibreMap, MapMouseEvent } from "maplibre-gl";
+
+/**
+ * Shift+ドラッグによる矩形選択（ラバーバンド）。
+ *
+ * - shift + mousedown で開始。map.dragPan を無効化してパンを抑止。
+ * - mousemove で矩形 div を更新表示。
+ * - mouseup でコールバックに bbox を渡す。MapLibre 側で
+ *   queryRenderedFeatures を呼ぶのは呼び出し側の責任。
+ * - ドラッグ距離が MIN_DRAG_PX 未満ならキャンセル（通常の shift+click に委ねる）。
+ * - Esc / window の mouseup（キャンバス外で離した場合）でもキャンセル。
+ */
+
+export interface RubberBandCallbacks {
+  /**
+   * 有効なドラッグが完了したときに呼ばれる。
+   * bbox は [[minX, minY], [maxX, maxY]] の screen pixel 座標（map canvas 基準）。
+   */
+  onRelease(bbox: [[number, number], [number, number]]): void;
+}
+
+const MIN_DRAG_PX = 5;
+
+export function attachRubberBand(
+  map: MapLibreMap,
+  cb: RubberBandCallbacks,
+): () => void {
+  const container = map.getContainer();
+  const box = document.createElement("div");
+  box.setAttribute("data-testid", "rubber-band");
+  Object.assign(box.style, {
+    position: "absolute",
+    pointerEvents: "none",
+    border: "1.5px dashed #ff8800",
+    background: "rgba(255, 136, 0, 0.12)",
+    zIndex: "5",
+    display: "none",
+    left: "0",
+    top: "0",
+    width: "0",
+    height: "0",
+  });
+  container.appendChild(box);
+
+  let start: { x: number; y: number } | null = null;
+
+  function onDown(e: MapMouseEvent): void {
+    if (!e.originalEvent.shiftKey) return;
+    start = { x: e.point.x, y: e.point.y };
+    map.dragPan.disable();
+  }
+
+  function onMove(e: MapMouseEvent): void {
+    if (!start) return;
+    const left = Math.min(start.x, e.point.x);
+    const top = Math.min(start.y, e.point.y);
+    const w = Math.abs(e.point.x - start.x);
+    const h = Math.abs(e.point.y - start.y);
+    box.style.display = "block";
+    box.style.left = `${left}px`;
+    box.style.top = `${top}px`;
+    box.style.width = `${w}px`;
+    box.style.height = `${h}px`;
+  }
+
+  function finalize(endPt: { x: number; y: number } | null): void {
+    if (!start) return;
+    const s = start;
+    start = null;
+    box.style.display = "none";
+    map.dragPan.enable();
+    if (!endPt) return;
+    const dx = endPt.x - s.x;
+    const dy = endPt.y - s.y;
+    if (Math.hypot(dx, dy) < MIN_DRAG_PX) return;
+    const p1: [number, number] = [Math.min(s.x, endPt.x), Math.min(s.y, endPt.y)];
+    const p2: [number, number] = [Math.max(s.x, endPt.x), Math.max(s.y, endPt.y)];
+    cb.onRelease([p1, p2]);
+  }
+
+  function onUp(e: MapMouseEvent): void {
+    finalize(e.point);
+  }
+
+  function onWindowUp(): void {
+    // map canvas 外で離された場合のフェイルセーフ。bbox 確定はしない。
+    if (start) finalize(null);
+  }
+
+  function onKeyDown(e: KeyboardEvent): void {
+    if (e.key === "Escape" && start) finalize(null);
+  }
+
+  map.on("mousedown", onDown);
+  map.on("mousemove", onMove);
+  map.on("mouseup", onUp);
+  window.addEventListener("mouseup", onWindowUp);
+  window.addEventListener("keydown", onKeyDown);
+
+  return () => {
+    map.off("mousedown", onDown);
+    map.off("mousemove", onMove);
+    map.off("mouseup", onUp);
+    window.removeEventListener("mouseup", onWindowUp);
+    window.removeEventListener("keydown", onKeyDown);
+    box.remove();
+  };
+}

--- a/tests/e2e/display-and-export.spec.ts
+++ b/tests/e2e/display-and-export.spec.ts
@@ -508,6 +508,64 @@ test("select → 強調 → toggle off → undo restores", async ({ page }) => {
   expect(await highlightCount()).toBe(1);
 });
 
+test("shift+drag rubber band selects multiple features", async ({ page }) => {
+  await page.goto("/");
+  await page.waitForFunction(() => document.body.dataset.mapReady === "true", null, {
+    timeout: 30_000,
+  });
+  await page.evaluate(() => {
+    const g = window as unknown as { __mlMap?: { setZoom(z: number): void } };
+    g.__mlMap?.setZoom(15);
+  });
+  await page.waitForFunction(
+    () => {
+      const g = window as unknown as {
+        __mlMap?: { getZoom(): number; isStyleLoaded(): boolean; areTilesLoaded(): boolean };
+      };
+      return (
+        !!g.__mlMap &&
+        Math.round(g.__mlMap.getZoom()) === 15 &&
+        g.__mlMap.isStyleLoaded() &&
+        g.__mlMap.areTilesLoaded()
+      );
+    },
+    null,
+    { timeout: 15_000 },
+  );
+
+  // canvas に直接 MouseEvent を dispatch してラバーバンドを起動。
+  // Playwright の keyboard.down('Shift') + mouse.down/move/up は MapLibre の
+  // mousedown ハンドラに shiftKey=true を伝えない環境がある（実際本環境で確認）。
+  // ここでは DOM レベルで同等の操作を再現する。
+  const selected = await page.evaluate(() => {
+    const canvas = document.querySelector(".maplibregl-canvas") as HTMLElement;
+    const rect = canvas.getBoundingClientRect();
+    const cx = canvas.clientWidth / 2;
+    const cy = canvas.clientHeight / 2;
+    const size = 300;
+    const p1 = { x: cx - size / 2, y: cy - size / 2 };
+    const p2 = { x: cx + size / 2, y: cy + size / 2 };
+    function mk(type: string, x: number, y: number): MouseEvent {
+      return new MouseEvent(type, {
+        bubbles: true,
+        cancelable: true,
+        view: window,
+        clientX: rect.left + x,
+        clientY: rect.top + y,
+        button: 0,
+        shiftKey: true,
+      });
+    }
+    canvas.dispatchEvent(mk("mousedown", p1.x, p1.y));
+    canvas.dispatchEvent(mk("mousemove", (p1.x + p2.x) / 2, (p1.y + p2.y) / 2));
+    canvas.dispatchEvent(mk("mousemove", p2.x, p2.y));
+    canvas.dispatchEvent(mk("mouseup", p2.x, p2.y));
+    const g = window as unknown as { __selectionStore?: { state: unknown[] } };
+    return g.__selectionStore?.state.length ?? 0;
+  });
+  expect(selected).toBeGreaterThan(1);
+});
+
 test("URL hash reflects view state after pan", async ({ page }) => {
   await page.goto("/");
   await page.waitForFunction(() => document.body.dataset.mapReady === "true", null, {


### PR DESCRIPTION
## Summary
- Shift+ドラッグで矩形範囲の feature を選択に一括追加
- 半透明の橙色ダッシュ矩形で領域可視化
- 5px 未満はキャンセル（shift+click にフォールスルー）
- Esc / map 外でのマウスアップでもキャンセル

## 技術的な気づき
MapLibre デフォルトの **`boxZoom`（shift+drag=矩形ズーム）** が競合していた。有効のままだと我々のラバーバンド div が描画されず、ドラッグ解除時にズームが変わる。`map.boxZoom.disable()` を明示。

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test` — 55件 Green
- [x] `pnpm e2e` — 8件 Green（矩形選択 1件新設）
- [x] ブラウザ実機で橙色ダッシュ矩形が追従表示されること確認
- [x] 矩形内 feature が一括で選択に入ることを確認

## Closes
Closes #17
