### PR TITLE
feat: ライン幅を runtime で +/- 調整（道路・鉄道・河川・境界）

### DIFF
--- a/index.html
+++ b/index.html
@@ -90,6 +90,69 @@
         display: inline-flex;
         gap: 6px;
       }
+      .line-width-wrap {
+        position: relative;
+      }
+      .line-width-popover {
+        position: absolute;
+        top: calc(100% + 6px);
+        right: 0;
+        background: #fff;
+        border: 1px solid #bbb;
+        border-radius: 6px;
+        box-shadow: 0 4px 14px rgba(0, 0, 0, 0.08);
+        padding: 10px 12px;
+        z-index: 10;
+        font-size: 13px;
+        min-width: 220px;
+      }
+      .line-width-popover[hidden] {
+        display: none;
+      }
+      .line-width-row {
+        display: grid;
+        grid-template-columns: 3em 1fr 3.2em 1fr;
+        align-items: center;
+        gap: 6px;
+        padding: 4px 0;
+      }
+      .line-width-row > .label {
+        color: #444;
+      }
+      .line-width-row > .value {
+        text-align: center;
+        color: #666;
+        font-variant-numeric: tabular-nums;
+      }
+      .line-width-row button {
+        appearance: none;
+        border: 1px solid #aaa;
+        background: #fff;
+        border-radius: 4px;
+        padding: 2px 0;
+        cursor: pointer;
+        font-size: 14px;
+      }
+      .line-width-row button:hover {
+        background: #f3f3f3;
+      }
+      .line-width-row button:disabled {
+        opacity: 0.4;
+        cursor: not-allowed;
+      }
+      .line-width-popover .reset {
+        width: 100%;
+        margin-top: 6px;
+        padding: 4px 8px;
+        border: 1px solid #aaa;
+        background: #fff;
+        border-radius: 4px;
+        cursor: pointer;
+        font-size: 12px;
+      }
+      .line-width-popover .reset:hover {
+        background: #f3f3f3;
+      }
       #map {
         width: 100%;
         height: 100%;
@@ -114,6 +177,36 @@
           <button id="reset-edits" class="primary" type="button" title="編集を全て破棄" disabled>
             編集をリセット
           </button>
+        </div>
+        <div class="line-width-wrap">
+          <button id="line-width-toggle" class="primary" type="button" aria-expanded="false" aria-controls="line-width-popover">太さ…</button>
+          <div id="line-width-popover" class="line-width-popover" role="dialog" aria-label="ライン幅調整" hidden>
+            <div class="line-width-row">
+              <span class="label">道路</span>
+              <button type="button" data-lw="road" data-op="dec" aria-label="道路を細く">−</button>
+              <span class="value" data-lw-value="road">1.00×</span>
+              <button type="button" data-lw="road" data-op="inc" aria-label="道路を太く">＋</button>
+            </div>
+            <div class="line-width-row">
+              <span class="label">鉄道</span>
+              <button type="button" data-lw="railway" data-op="dec" aria-label="鉄道を細く">−</button>
+              <span class="value" data-lw-value="railway">1.00×</span>
+              <button type="button" data-lw="railway" data-op="inc" aria-label="鉄道を太く">＋</button>
+            </div>
+            <div class="line-width-row">
+              <span class="label">河川</span>
+              <button type="button" data-lw="river" data-op="dec" aria-label="河川を細く">−</button>
+              <span class="value" data-lw-value="river">1.00×</span>
+              <button type="button" data-lw="river" data-op="inc" aria-label="河川を太く">＋</button>
+            </div>
+            <div class="line-width-row">
+              <span class="label">境界</span>
+              <button type="button" data-lw="boundary" data-op="dec" aria-label="境界を細く">−</button>
+              <span class="value" data-lw-value="boundary">1.00×</span>
+              <button type="button" data-lw="boundary" data-op="inc" aria-label="境界を太く">＋</button>
+            </div>
+            <button type="button" class="reset" id="line-width-reset">すべて初期値に戻す</button>
+          </div>
         </div>
         <button id="export-png" class="primary" type="button">PNG書き出し</button>
       </header>

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,6 +16,13 @@ import {
   setHighlightOverlayData,
 } from "./map/highlightOverlay";
 import { attachRubberBand } from "./map/rubberBand";
+import { applyLineWidthFactors } from "./map/lineWidth";
+import {
+  LineWidthStore,
+  LINE_WIDTH_MAX,
+  LINE_WIDTH_MIN,
+  type LineWidthCategory,
+} from "./state/lineWidthStore";
 import {
   DEFAULT_VIEW,
   decodeHashToView,
@@ -48,12 +55,16 @@ const highlightBtn = requireEl("highlight", HTMLButtonElement);
 const deleteBtn = requireEl("delete", HTMLButtonElement);
 const resetEditsBtn = requireEl("reset-edits", HTMLButtonElement);
 const selectionCountEl = requireEl("selection-count", HTMLSpanElement);
+const lineWidthToggle = requireEl("line-width-toggle", HTMLButtonElement);
+const lineWidthPopover = requireEl("line-width-popover", HTMLElement);
+const lineWidthResetBtn = requireEl("line-width-reset", HTMLButtonElement);
 
 const initialView: ViewState = decodeHashToView(window.location.hash) ?? DEFAULT_VIEW;
 let currentPreset: Preset = "standard";
 const editState = new EditStateStore();
 const selectionStore = new SelectionStore();
 const history = new History<EditStateSnapshot>();
+const lineWidthStore = new LineWidthStore();
 
 const map: MapLibreMap = new maplibregl.Map({
   container: mapRoot,
@@ -102,15 +113,18 @@ function refreshOverlays(): void {
 
 map.on("load", () => {
   refreshOverlays();
+  applyLineWidthFactors(map, lineWidthStore.factors);
   document.body.dataset["mapReady"] = "true";
 });
 
 // preset 切替は setStyle を伴い overlay を飛ばすことがある。
 // styledata はその後何度か発火するが、isStyleLoaded() が真になってから
 // overlay を復元する（もしくは色を追従させる）。
+// line-width factor も preset 切替で初期値に戻るので再適用する。
 map.on("styledata", () => {
   if (!map.isStyleLoaded()) return;
   refreshOverlays();
+  applyLineWidthFactors(map, lineWidthStore.factors);
 });
 
 editState.subscribe((s) => {
@@ -141,11 +155,13 @@ if (import.meta.env.DEV) {
     __editState?: EditStateStore;
     __selectionStore?: SelectionStore;
     __history?: History<EditStateSnapshot>;
+    __lineWidthStore?: LineWidthStore;
   };
   w.__mlMap = map;
   w.__editState = editState;
   w.__selectionStore = selectionStore;
   w.__history = history;
+  w.__lineWidthStore = lineWidthStore;
 }
 
 function applyPreset(next: Preset): void {
@@ -299,6 +315,71 @@ window.addEventListener("keydown", (e) => {
     e.preventDefault();
     redo();
   }
+});
+
+// ---- ライン幅調整 UI ----
+
+const LINE_WIDTH_CATEGORIES: LineWidthCategory[] = ["road", "railway", "river", "boundary"];
+
+function updateLineWidthUI(): void {
+  const f = lineWidthStore.factors;
+  for (const cat of LINE_WIDTH_CATEGORIES) {
+    const valueEl = lineWidthPopover.querySelector(`[data-lw-value="${cat}"]`);
+    if (valueEl) valueEl.textContent = `${f[cat].toFixed(2)}×`;
+    const decBtn = lineWidthPopover.querySelector(
+      `button[data-lw="${cat}"][data-op="dec"]`,
+    );
+    const incBtn = lineWidthPopover.querySelector(
+      `button[data-lw="${cat}"][data-op="inc"]`,
+    );
+    if (decBtn instanceof HTMLButtonElement) {
+      decBtn.disabled = f[cat] <= LINE_WIDTH_MIN + 1e-9;
+    }
+    if (incBtn instanceof HTMLButtonElement) {
+      incBtn.disabled = f[cat] >= LINE_WIDTH_MAX - 1e-9;
+    }
+  }
+}
+
+lineWidthStore.subscribe((f) => {
+  applyLineWidthFactors(map, f);
+  updateLineWidthUI();
+});
+updateLineWidthUI();
+
+lineWidthPopover.addEventListener("click", (e) => {
+  const target = e.target;
+  if (!(target instanceof HTMLButtonElement)) return;
+  const cat = target.getAttribute("data-lw") as LineWidthCategory | null;
+  const op = target.getAttribute("data-op");
+  if (!cat || !LINE_WIDTH_CATEGORIES.includes(cat)) return;
+  if (op === "inc") lineWidthStore.increase(cat);
+  else if (op === "dec") lineWidthStore.decrease(cat);
+});
+
+lineWidthResetBtn.addEventListener("click", () => {
+  lineWidthStore.reset();
+});
+
+function setPopoverOpen(open: boolean): void {
+  if (open) {
+    lineWidthPopover.hidden = false;
+    lineWidthToggle.setAttribute("aria-expanded", "true");
+  } else {
+    lineWidthPopover.hidden = true;
+    lineWidthToggle.setAttribute("aria-expanded", "false");
+  }
+}
+lineWidthToggle.addEventListener("click", () => {
+  setPopoverOpen(lineWidthPopover.hidden);
+});
+// ポップオーバー外クリックで閉じる（トグル自身とポップオーバー内クリックは除外）
+document.addEventListener("click", (e) => {
+  if (lineWidthPopover.hidden) return;
+  const t = e.target;
+  if (!(t instanceof Node)) return;
+  if (lineWidthPopover.contains(t) || lineWidthToggle.contains(t)) return;
+  setPopoverOpen(false);
 });
 
 exportButton.addEventListener("click", async () => {

--- a/src/map/lineWidth.ts
+++ b/src/map/lineWidth.ts
@@ -1,0 +1,51 @@
+import type { Map as MapLibreMap } from "maplibre-gl";
+import {
+  BASE_BOUNDARY_WIDTH,
+  BASE_RAILWAY_WIDTH,
+  BASE_RIVER_WIDTH,
+  BASE_ROAD_WIDTH,
+} from "./style";
+import {
+  scaleLineWidth,
+  type LineWidthFactors,
+} from "../state/lineWidthStore";
+
+/**
+ * LineWidthFactors を MapLibre の paint プロパティに反映。
+ * preset 切替後（styledata）にも呼び出して再適用する。
+ */
+export function applyLineWidthFactors(
+  map: MapLibreMap,
+  factors: LineWidthFactors,
+): void {
+  if (map.getLayer("road-line")) {
+    map.setPaintProperty(
+      "road-line",
+      "line-width",
+      scaleLineWidth(BASE_ROAD_WIDTH as unknown as unknown[], factors.road) as
+        | number
+        | unknown[],
+    );
+  }
+  if (map.getLayer("railway-line")) {
+    map.setPaintProperty(
+      "railway-line",
+      "line-width",
+      scaleLineWidth(BASE_RAILWAY_WIDTH, factors.railway) as number,
+    );
+  }
+  if (map.getLayer("river-line")) {
+    map.setPaintProperty(
+      "river-line",
+      "line-width",
+      scaleLineWidth(BASE_RIVER_WIDTH, factors.river) as number,
+    );
+  }
+  if (map.getLayer("boundary-line")) {
+    map.setPaintProperty(
+      "boundary-line",
+      "line-width",
+      scaleLineWidth(BASE_BOUNDARY_WIDTH, factors.boundary) as number,
+    );
+  }
+}

--- a/src/map/style.ts
+++ b/src/map/style.ts
@@ -33,6 +33,25 @@ interface PresetPalette {
   boundary: string;
 }
 
+/**
+ * 基準となる line-width。runtime で factor 調整する #24 で参照される。
+ * ここを単一の source of truth とする。
+ */
+export const BASE_ROAD_WIDTH = [
+  "interpolate",
+  ["linear"],
+  ["zoom"],
+  10,
+  0.3,
+  14,
+  1.0,
+  16,
+  2.4,
+] as const;
+export const BASE_RAILWAY_WIDTH = 1.1;
+export const BASE_RIVER_WIDTH = 0.8;
+export const BASE_BOUNDARY_WIDTH = 0.5;
+
 export const PALETTES: Record<Preset, PresetPalette> = {
   standard: {
     bg: "#fafafa",
@@ -93,14 +112,14 @@ export function buildBaseStyle(preset: Preset = "standard"): StyleSpecification 
         type: "line",
         source: SOURCE_ID,
         "source-layer": "river",
-        paint: { "line-color": c.river, "line-width": 0.8 },
+        paint: { "line-color": c.river, "line-width": BASE_RIVER_WIDTH },
       },
       {
         id: "railway-line",
         type: "line",
         source: SOURCE_ID,
         "source-layer": "railway",
-        paint: { "line-color": c.railway, "line-width": 1.1 },
+        paint: { "line-color": c.railway, "line-width": BASE_RAILWAY_WIDTH },
       },
       {
         id: "road-line",
@@ -109,17 +128,7 @@ export function buildBaseStyle(preset: Preset = "standard"): StyleSpecification 
         "source-layer": "road",
         paint: {
           "line-color": c.road,
-          "line-width": [
-            "interpolate",
-            ["linear"],
-            ["zoom"],
-            10,
-            0.3,
-            14,
-            1.0,
-            16,
-            2.4,
-          ],
+          "line-width": BASE_ROAD_WIDTH as unknown as number,
         },
       },
       {
@@ -140,7 +149,7 @@ export function buildBaseStyle(preset: Preset = "standard"): StyleSpecification 
         "source-layer": "boundary",
         paint: {
           "line-color": c.boundary,
-          "line-width": 0.5,
+          "line-width": BASE_BOUNDARY_WIDTH,
           "line-dasharray": [3, 2],
         },
       },

--- a/src/state/lineWidthStore.ts
+++ b/src/state/lineWidthStore.ts
@@ -1,0 +1,113 @@
+/**
+ * ライン幅の調整 factor を保持する store。
+ *
+ * 対象 4 カテゴリ（道路・鉄道・河川・境界）ごとに 1.0 を基準とする倍率。
+ * +/- は幾何級数（×1.25 / ÷1.25）、クランプは [0.2, 8.0]。
+ *
+ * 履歴（Undo/Redo）には乗せない — view 設定的な扱い（#24 設計判断）。
+ */
+
+export type LineWidthCategory = "road" | "railway" | "river" | "boundary";
+
+export interface LineWidthFactors {
+  road: number;
+  railway: number;
+  river: number;
+  boundary: number;
+}
+
+export const DEFAULT_LINE_WIDTH_FACTORS: LineWidthFactors = {
+  road: 1,
+  railway: 1,
+  river: 1,
+  boundary: 1,
+};
+
+export const LINE_WIDTH_STEP = 1.25;
+export const LINE_WIDTH_MIN = 0.2;
+export const LINE_WIDTH_MAX = 8.0;
+
+type Listener = (f: LineWidthFactors) => void;
+
+function clamp(x: number): number {
+  return Math.min(LINE_WIDTH_MAX, Math.max(LINE_WIDTH_MIN, x));
+}
+
+function nearlyEqual(a: number, b: number): boolean {
+  return Math.abs(a - b) < 1e-9;
+}
+
+export class LineWidthStore {
+  private _factors: LineWidthFactors = { ...DEFAULT_LINE_WIDTH_FACTORS };
+  private _listeners = new Set<Listener>();
+
+  get factors(): Readonly<LineWidthFactors> {
+    return { ...this._factors };
+  }
+
+  increase(key: LineWidthCategory): void {
+    const next = clamp(this._factors[key] * LINE_WIDTH_STEP);
+    if (nearlyEqual(next, this._factors[key])) return;
+    this._factors[key] = next;
+    this._emit();
+  }
+
+  decrease(key: LineWidthCategory): void {
+    const next = clamp(this._factors[key] / LINE_WIDTH_STEP);
+    if (nearlyEqual(next, this._factors[key])) return;
+    this._factors[key] = next;
+    this._emit();
+  }
+
+  reset(): void {
+    const def = DEFAULT_LINE_WIDTH_FACTORS;
+    if (
+      nearlyEqual(this._factors.road, def.road) &&
+      nearlyEqual(this._factors.railway, def.railway) &&
+      nearlyEqual(this._factors.river, def.river) &&
+      nearlyEqual(this._factors.boundary, def.boundary)
+    ) {
+      return;
+    }
+    this._factors = { ...def };
+    this._emit();
+  }
+
+  subscribe(l: Listener): () => void {
+    this._listeners.add(l);
+    return () => {
+      this._listeners.delete(l);
+    };
+  }
+
+  private _emit(): void {
+    const snapshot = this.factors;
+    for (const l of this._listeners) l(snapshot);
+  }
+}
+
+/**
+ * MapLibre の line-width 値（数値または interpolate 式）を倍率でスケール。
+ *
+ * interpolate 式は ["interpolate", ["linear"], ["zoom"], z1, v1, z2, v2, ...] の形を想定し、
+ * 値の stop 部分だけに factor を掛けた式を返す。
+ */
+export function scaleLineWidth(
+  base: number | unknown[],
+  factor: number,
+): number | unknown[] {
+  if (typeof base === "number") {
+    return base * factor;
+  }
+  if (Array.isArray(base) && base[0] === "interpolate") {
+    const out: unknown[] = [base[0], base[1], base[2]];
+    for (let i = 3; i < base.length; i += 2) {
+      const zoom = base[i];
+      const val = base[i + 1];
+      out.push(zoom);
+      out.push(typeof val === "number" ? val * factor : val);
+    }
+    return out;
+  }
+  return base;
+}

--- a/tests/e2e/display-and-export.spec.ts
+++ b/tests/e2e/display-and-export.spec.ts
@@ -566,6 +566,71 @@ test("shift+drag rubber band selects multiple features", async ({ page }) => {
   expect(selected).toBeGreaterThan(1);
 });
 
+test("line-width popover + / - / reset changes paint-property", async ({ page }) => {
+  await page.goto("/");
+  await page.waitForFunction(() => document.body.dataset.mapReady === "true", null, {
+    timeout: 30_000,
+  });
+
+  // 初期 road line-width 式を取得
+  const initialRoad = await page.evaluate(() => {
+    const g = window as unknown as {
+      __mlMap?: { getPaintProperty(id: string, prop: string): unknown };
+    };
+    return g.__mlMap!.getPaintProperty("road-line", "line-width");
+  });
+  // 初期は interpolate 式（配列形）で stop 値が [0.3, 1.0, 2.4]
+  expect(Array.isArray(initialRoad)).toBe(true);
+
+  // ポップオーバーを開く
+  await page.locator("#line-width-toggle").click();
+  await expect(page.locator("#line-width-popover")).toBeVisible();
+
+  // 道路を太く（×1.25）
+  await page.locator('button[data-lw="road"][data-op="inc"]').click();
+  const afterInc = await page.evaluate(() => {
+    const g = window as unknown as {
+      __mlMap?: { getPaintProperty(id: string, prop: string): unknown };
+    };
+    return g.__mlMap!.getPaintProperty("road-line", "line-width");
+  });
+  // stop 値が 1.25 倍になっていること
+  // interpolate 式は ["interpolate", ["linear"], ["zoom"], z1, v1, z2, v2, ...] 。
+  // 値stop は index 4, 6, 8, ... （3番目以降の偶数）。
+  const stopsInc = (afterInc as unknown[]).slice(3).filter((_, i) => i % 2 === 1) as number[];
+  expect(stopsInc[0]).toBeCloseTo(0.3 * 1.25, 5);
+  expect(stopsInc[2]).toBeCloseTo(2.4 * 1.25, 5);
+
+  // 表示ラベルも更新される
+  await expect(page.locator('[data-lw-value="road"]')).toHaveText("1.25×");
+
+  // 鉄道を細く
+  await page.locator('button[data-lw="railway"][data-op="dec"]').click();
+  const railway = await page.evaluate(() => {
+    const g = window as unknown as {
+      __mlMap?: { getPaintProperty(id: string, prop: string): unknown };
+    };
+    return g.__mlMap!.getPaintProperty("railway-line", "line-width");
+  });
+  expect(railway).toBeCloseTo(1.1 / 1.25, 5);
+
+  // リセット
+  await page.locator("#line-width-reset").click();
+  await expect(page.locator('[data-lw-value="road"]')).toHaveText("1.00×");
+  const reset = await page.evaluate(() => {
+    const g = window as unknown as {
+      __mlMap?: { getPaintProperty(id: string, prop: string): unknown };
+    };
+    return {
+      road: g.__mlMap!.getPaintProperty("road-line", "line-width"),
+      railway: g.__mlMap!.getPaintProperty("railway-line", "line-width"),
+    };
+  });
+  const resetStops = (reset.road as unknown[]).slice(3).filter((_, i) => i % 2 === 1) as number[];
+  expect(resetStops[0]).toBeCloseTo(0.3, 5);
+  expect(reset.railway).toBeCloseTo(1.1, 5);
+});
+
 test("URL hash reflects view state after pan", async ({ page }) => {
   await page.goto("/");
   await page.waitForFunction(() => document.body.dataset.mapReady === "true", null, {

--- a/tests/unit/lineWidthStore.test.ts
+++ b/tests/unit/lineWidthStore.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  LineWidthStore,
+  scaleLineWidth,
+  DEFAULT_LINE_WIDTH_FACTORS,
+  LINE_WIDTH_MIN,
+  LINE_WIDTH_MAX,
+} from "../../src/state/lineWidthStore";
+
+describe("scaleLineWidth", () => {
+  it("scales a numeric line-width", () => {
+    expect(scaleLineWidth(1.1, 2)).toBe(2.2);
+    expect(scaleLineWidth(0.8, 0.5)).toBe(0.4);
+  });
+
+  it("preserves base expression header and scales each stop value of interpolate", () => {
+    const base = ["interpolate", ["linear"], ["zoom"], 10, 0.3, 14, 1.0, 16, 2.4] as const;
+    const scaled = scaleLineWidth(base as unknown as unknown[], 2);
+    expect(scaled).toEqual(["interpolate", ["linear"], ["zoom"], 10, 0.6, 14, 2.0, 16, 4.8]);
+  });
+
+  it("returns the base untouched for factor=1", () => {
+    expect(scaleLineWidth(1.1, 1)).toBe(1.1);
+  });
+});
+
+describe("LineWidthStore", () => {
+  it("starts at 1.0 for all categories", () => {
+    const s = new LineWidthStore();
+    expect(s.factors).toEqual(DEFAULT_LINE_WIDTH_FACTORS);
+  });
+
+  it("increase multiplies factor by 1.25", () => {
+    const s = new LineWidthStore();
+    s.increase("road");
+    expect(s.factors.road).toBeCloseTo(1.25, 5);
+  });
+
+  it("decrease divides factor by 1.25", () => {
+    const s = new LineWidthStore();
+    s.decrease("road");
+    expect(s.factors.road).toBeCloseTo(1 / 1.25, 5);
+  });
+
+  it("clamps at LINE_WIDTH_MAX when increasing beyond upper bound", () => {
+    const s = new LineWidthStore();
+    for (let i = 0; i < 30; i++) s.increase("road");
+    expect(s.factors.road).toBe(LINE_WIDTH_MAX);
+  });
+
+  it("clamps at LINE_WIDTH_MIN when decreasing below lower bound", () => {
+    const s = new LineWidthStore();
+    for (let i = 0; i < 30; i++) s.decrease("road");
+    expect(s.factors.road).toBe(LINE_WIDTH_MIN);
+  });
+
+  it("reset restores all factors to 1.0 and fires listener", () => {
+    const s = new LineWidthStore();
+    s.increase("road");
+    s.decrease("railway");
+    const l = vi.fn();
+    s.subscribe(l);
+    s.reset();
+    expect(s.factors).toEqual(DEFAULT_LINE_WIDTH_FACTORS);
+    expect(l).toHaveBeenCalledTimes(1);
+  });
+
+  it("reset when already default does not fire listener", () => {
+    const s = new LineWidthStore();
+    const l = vi.fn();
+    s.subscribe(l);
+    s.reset();
+    expect(l).not.toHaveBeenCalled();
+  });
+
+  it("subscribe fires on increase/decrease", () => {
+    const s = new LineWidthStore();
+    const l = vi.fn();
+    s.subscribe(l);
+    s.increase("river");
+    s.decrease("boundary");
+    expect(l).toHaveBeenCalledTimes(2);
+  });
+
+  it("increase at MAX is a no-op (no listener call)", () => {
+    const s = new LineWidthStore();
+    for (let i = 0; i < 30; i++) s.increase("road");
+    const l = vi.fn();
+    s.subscribe(l);
+    s.increase("road");
+    expect(l).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- 道路・鉄道・河川・境界の line-width を runtime で ×1.25 / ÷1.25 調整
- ヘッダ「太さ…」ボタン → ポップオーバーで 4 カテゴリの − / 値 / + 操作
- 「すべて初期値に戻す」で一括復帰
- preset 切替後も factor 維持（styledata で再適用）
- PNG 書き出しに反映

## 設計
- `scaleLineWidth` 純関数: 数値 / interpolate 式 両対応
- 倍率クランプ [0.2, 8.0]、min/max でボタン disabled
- Undo/Redo には乗せない（view 設定扱い）

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test` — 67件 Green（lineWidthStore 12件新設）
- [x] `pnpm e2e` — 9件 Green（ポップオーバー +/- / reset を検証）
- [x] ブラウザ実機で道路・鉄道を 1.95× に調整 → 視覚的に明瞭に太くなる

## Closes
Closes #24
