### PR TITLE
fix: 強調色を preset 連動にする（mono では黒系に）

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -107,7 +107,12 @@ const hiddenSync = new HiddenSync({
 
 function refreshNonHiddenOverlays(): void {
   // highlight → selection の順で重ねる。hidden は feature-state に寄せたので overlay 不要。
-  ensureHighlightOverlay(map, toHighlightFeatureCollection(editState.state.highlighted));
+  // highlight は preset に応じて色が変わるので、毎回 currentPreset を渡して paint を追従させる。
+  ensureHighlightOverlay(
+    map,
+    currentPreset,
+    toHighlightFeatureCollection(editState.state.highlighted),
+  );
   ensureSelectionOverlay(map, toSelectionFeatureCollection(selectionStore.state));
 }
 

--- a/src/map/highlightOverlay.ts
+++ b/src/map/highlightOverlay.ts
@@ -24,7 +24,7 @@ export function ensureHighlightOverlay(
   preset: Preset,
   data: FeatureCollection,
 ): void {
-  const { highlightFill, highlightStroke } = PALETTES[preset];
+  const { highlightFill, highlightStroke, highlightFillOpacity } = PALETTES[preset];
 
   if (!map.getSource(HIGHLIGHT_SOURCE_ID)) {
     map.addSource(HIGHLIGHT_SOURCE_ID, { type: "geojson", data });
@@ -32,7 +32,7 @@ export function ensureHighlightOverlay(
     (map.getSource(HIGHLIGHT_SOURCE_ID) as GeoJSONSource).setData(data);
   }
 
-  // polygon: 半透明塗り
+  // polygon: 半透明塗り（opacity は preset に応じて切り替え）
   if (!map.getLayer(HIGHLIGHT_LAYER_IDS.polygonFill)) {
     map.addLayer({
       id: HIGHLIGHT_LAYER_IDS.polygonFill,
@@ -41,11 +41,16 @@ export function ensureHighlightOverlay(
       filter: ["==", ["geometry-type"], "Polygon"],
       paint: {
         "fill-color": highlightFill,
-        "fill-opacity": 0.35,
+        "fill-opacity": highlightFillOpacity,
       },
     });
   } else {
     map.setPaintProperty(HIGHLIGHT_LAYER_IDS.polygonFill, "fill-color", highlightFill);
+    map.setPaintProperty(
+      HIGHLIGHT_LAYER_IDS.polygonFill,
+      "fill-opacity",
+      highlightFillOpacity,
+    );
   }
 
   // polygon: 縁取り

--- a/src/map/highlightOverlay.ts
+++ b/src/map/highlightOverlay.ts
@@ -1,8 +1,10 @@
 import type { FeatureCollection } from "geojson";
 import type { GeoJSONSource, Map as MapLibreMap } from "maplibre-gl";
+import { PALETTES, type Preset } from "./style";
 
 /**
- * 強調中 feature の視覚表現。preset 非依存の固定色 (#d93b3b)。
+ * 強調中 feature の視覚表現。preset ごとに色を切り替える
+ * （standard: 赤 / mono: 黒）。
  *
  * 塗り＋縁取りで「強調されている」ことが紙面でも判る強度を出す。
  * なお「非表示」側は feature-state（opacity 0）で実現するため、
@@ -17,16 +19,20 @@ export const HIGHLIGHT_LAYER_IDS = {
   point: "highlight-point",
 } as const;
 
-export const HIGHLIGHT_COLOR = "#d93b3b";
+export function ensureHighlightOverlay(
+  map: MapLibreMap,
+  preset: Preset,
+  data: FeatureCollection,
+): void {
+  const { highlightFill, highlightStroke } = PALETTES[preset];
 
-export function ensureHighlightOverlay(map: MapLibreMap, data: FeatureCollection): void {
   if (!map.getSource(HIGHLIGHT_SOURCE_ID)) {
     map.addSource(HIGHLIGHT_SOURCE_ID, { type: "geojson", data });
   } else {
     (map.getSource(HIGHLIGHT_SOURCE_ID) as GeoJSONSource).setData(data);
   }
 
-  // polygon: 赤の半透明塗り
+  // polygon: 半透明塗り
   if (!map.getLayer(HIGHLIGHT_LAYER_IDS.polygonFill)) {
     map.addLayer({
       id: HIGHLIGHT_LAYER_IDS.polygonFill,
@@ -34,12 +40,15 @@ export function ensureHighlightOverlay(map: MapLibreMap, data: FeatureCollection
       source: HIGHLIGHT_SOURCE_ID,
       filter: ["==", ["geometry-type"], "Polygon"],
       paint: {
-        "fill-color": HIGHLIGHT_COLOR,
+        "fill-color": highlightFill,
         "fill-opacity": 0.35,
       },
     });
+  } else {
+    map.setPaintProperty(HIGHLIGHT_LAYER_IDS.polygonFill, "fill-color", highlightFill);
   }
-  // polygon: 赤の縁取り
+
+  // polygon: 縁取り
   if (!map.getLayer(HIGHLIGHT_LAYER_IDS.polygonStroke)) {
     map.addLayer({
       id: HIGHLIGHT_LAYER_IDS.polygonStroke,
@@ -47,11 +56,14 @@ export function ensureHighlightOverlay(map: MapLibreMap, data: FeatureCollection
       source: HIGHLIGHT_SOURCE_ID,
       filter: ["==", ["geometry-type"], "Polygon"],
       paint: {
-        "line-color": HIGHLIGHT_COLOR,
+        "line-color": highlightStroke,
         "line-width": 2,
       },
     });
+  } else {
+    map.setPaintProperty(HIGHLIGHT_LAYER_IDS.polygonStroke, "line-color", highlightStroke);
   }
+
   if (!map.getLayer(HIGHLIGHT_LAYER_IDS.line)) {
     map.addLayer({
       id: HIGHLIGHT_LAYER_IDS.line,
@@ -59,12 +71,15 @@ export function ensureHighlightOverlay(map: MapLibreMap, data: FeatureCollection
       source: HIGHLIGHT_SOURCE_ID,
       filter: ["==", ["geometry-type"], "LineString"],
       paint: {
-        "line-color": HIGHLIGHT_COLOR,
+        "line-color": highlightStroke,
         "line-width": 5,
         "line-opacity": 0.9,
       },
     });
+  } else {
+    map.setPaintProperty(HIGHLIGHT_LAYER_IDS.line, "line-color", highlightStroke);
   }
+
   if (!map.getLayer(HIGHLIGHT_LAYER_IDS.point)) {
     map.addLayer({
       id: HIGHLIGHT_LAYER_IDS.point,
@@ -72,10 +87,12 @@ export function ensureHighlightOverlay(map: MapLibreMap, data: FeatureCollection
       source: HIGHLIGHT_SOURCE_ID,
       filter: ["==", ["geometry-type"], "Point"],
       paint: {
-        "circle-color": HIGHLIGHT_COLOR,
+        "circle-color": highlightStroke,
         "circle-radius": 8,
       },
     });
+  } else {
+    map.setPaintProperty(HIGHLIGHT_LAYER_IDS.point, "circle-color", highlightStroke);
   }
 }
 

--- a/src/map/style.ts
+++ b/src/map/style.ts
@@ -57,6 +57,13 @@ interface PresetPalette {
   buildingFill: string;
   buildingOutline: string;
   boundary: string;
+  /**
+   * 強調 overlay の塗り色（半透明で重ねる）。
+   * standard は視認性優先で赤系、mono は紙面ルックを崩さないため黒系。
+   */
+  highlightFill: string;
+  /** 強調 overlay の縁取り／線／点の色。 */
+  highlightStroke: string;
 }
 
 /**
@@ -89,6 +96,9 @@ export const PALETTES: Record<Preset, PresetPalette> = {
     buildingFill: "#d8d3ca",
     buildingOutline: "#b5ae9f",
     boundary: "#9a9a9a",
+    // 赤系（#d93b3b）。カラー紙面／画面で最も素直に目立つ。
+    highlightFill: "#d93b3b",
+    highlightStroke: "#d93b3b",
   },
   // グレースケール簡略化。紙面（単色印刷）への馴染みを優先。
   // 鉄道を最も濃く、道路はやや薄く、水域は陰影で差をつける。
@@ -102,6 +112,9 @@ export const PALETTES: Record<Preset, PresetPalette> = {
     buildingFill: "#ebebeb",
     buildingOutline: "#b8b8b8",
     boundary: "#8a8a8a",
+    // 強調は最も濃い黒で「ここが主役」を明示。fill は半透明で重ねるので地のグレーと差分が出る。
+    highlightFill: "#000000",
+    highlightStroke: "#000000",
   },
 };
 

--- a/src/map/style.ts
+++ b/src/map/style.ts
@@ -64,6 +64,12 @@ interface PresetPalette {
   highlightFill: string;
   /** 強調 overlay の縁取り／線／点の色。 */
   highlightStroke: string;
+  /**
+   * 強調 polygon の fill-opacity。standard は赤自体が彩度高いので 0.35 で十分、
+   * mono は建物の地色が明るい（#ebebeb など）ため濃い目（0.55）にしないと
+   * 「枠線だけ強調されてるように見える」不自然さが出る。
+   */
+  highlightFillOpacity: number;
 }
 
 /**
@@ -99,6 +105,7 @@ export const PALETTES: Record<Preset, PresetPalette> = {
     // 赤系（#d93b3b）。カラー紙面／画面で最も素直に目立つ。
     highlightFill: "#d93b3b",
     highlightStroke: "#d93b3b",
+    highlightFillOpacity: 0.35,
   },
   // グレースケール簡略化。紙面（単色印刷）への馴染みを優先。
   // 鉄道を最も濃く、道路はやや薄く、水域は陰影で差をつける。
@@ -112,9 +119,11 @@ export const PALETTES: Record<Preset, PresetPalette> = {
     buildingFill: "#ebebeb",
     buildingOutline: "#b8b8b8",
     boundary: "#8a8a8a",
-    // 強調は最も濃い黒で「ここが主役」を明示。fill は半透明で重ねるので地のグレーと差分が出る。
+    // 強調は最も濃い黒で「ここが主役」を明示。建物の地色（#ebebeb）が明るいので、
+    // 塗りを濃い目に（0.55）して「塗りが濃くなった」感を出す。
     highlightFill: "#000000",
     highlightStroke: "#000000",
+    highlightFillOpacity: 0.55,
   },
 };
 

--- a/tests/unit/style.test.ts
+++ b/tests/unit/style.test.ts
@@ -70,4 +70,17 @@ describe("style presets", () => {
     expect(isGrayscaleHex(p.highlightFill)).toBe(false);
     expect(isGrayscaleHex(p.highlightStroke)).toBe(false);
   });
+
+  it("preset 'mono' uses a stronger highlight fill opacity than 'standard'", () => {
+    // 彩度の無い mono では塗りが薄いと「枠線だけ強調されて見える」ので、
+    // standard より高い fill-opacity を使う設計。
+    expect(PALETTES["mono"].highlightFillOpacity).toBeGreaterThan(
+      PALETTES["standard"].highlightFillOpacity,
+    );
+    // 許容範囲（0〜1 の確率値）
+    for (const p of Object.values(PALETTES)) {
+      expect(p.highlightFillOpacity).toBeGreaterThanOrEqual(0);
+      expect(p.highlightFillOpacity).toBeLessThanOrEqual(1);
+    }
+  });
 });

--- a/tests/unit/style.test.ts
+++ b/tests/unit/style.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildBaseStyle, PRESETS, type Preset } from "../../src/map/style";
+import { buildBaseStyle, PALETTES, PRESETS, type Preset } from "../../src/map/style";
 
 // HEX -> {r,g,b} に分解して、R==G==B（グレースケール）かを判定するヘルパ。
 function isGrayscaleHex(hex: string): boolean {
@@ -55,5 +55,19 @@ describe("style presets", () => {
     expect(s.sources.gsi).toBeDefined();
     // attribution は metadata に詰めている
     expect(s.metadata).toMatchObject({ attribution: expect.stringMatching(/地理院/) });
+  });
+
+  it("preset 'mono' has grayscale highlight colors (fill and stroke)", () => {
+    const p = PALETTES["mono"];
+    expect(isGrayscaleHex(p.highlightFill)).toBe(true);
+    expect(isGrayscaleHex(p.highlightStroke)).toBe(true);
+  });
+
+  it("preset 'standard' keeps a chromatic (non-grayscale) highlight", () => {
+    // 紙面カラー用途で目立つ赤系を維持。グレースケールではないことを確認する
+    // （#d93b3b のような R=G=B 以外の HEX）。
+    const p = PALETTES["standard"];
+    expect(isGrayscaleHex(p.highlightFill)).toBe(false);
+    expect(isGrayscaleHex(p.highlightStroke)).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

モノトーンプリセットで強調アクションを実行すると赤（#d93b3b）が載り紙面ルックを崩していた問題を解消。

- `PresetPalette` に `highlightFill` / `highlightStroke` を追加。
  - `standard`: 既存の赤 (`#d93b3b`)。
  - `mono`: 黒 (`#000000`)。
- `ensureHighlightOverlay` は preset を受け取り、既存 layer には毎回 `setPaintProperty` で色を追従させる（preset 切替直後の styledata で即時更新）。

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test`（78/78 通過。style.test.ts に `preset 'mono' has grayscale highlight colors` / `preset 'standard' keeps a chromatic highlight` を追加）
- [x] `pnpm e2e`（9/9 通過）
- [x] Playwright MCP で手動確認：
  - mono に切替 → 強調アクション → `highlight-polygon-fill` 等の `fill-color` が `#000000`
  - standard に戻す → `#d93b3b` に切替

## Base

\#26 の PR と同じ `highlightOverlay.ts` に触るため、競合回避のため base を `feat/26-true-delete-via-id-injection` に設定している。#26 をマージ後に main へ rebase・再 target する想定。