### PR TITLE
fix: preset 切替後に overlay を idle で再構築する (v0.3.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "map-simplifier",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/main.ts
+++ b/src/main.ts
@@ -276,6 +276,18 @@ function applyPreset(next: Preset): void {
   if (next === currentPreset) return;
   currentPreset = next;
   map.setStyle(buildBaseStyle(next), { diff: true });
+  // setStyle({ diff: true }) は custom source/layer を取り去ったうえで
+  // styledata を isStyleLoaded=false のまま 1 回だけ発火し、isStyleLoaded=true の
+  // styledata が後から来ないケースがある（実測）。既存の styledata ハンドラは
+  // isStyleLoaded ガードで早期 return するため overlay が復元されず、特に mono では
+  // 選択の橙縁取りが消失したまま戻らない症状になっていた。
+  // style が落ち着く idle を一度だけ待って、確実に overlay 群を再構築する。
+  map.once("idle", () => {
+    refreshNonHiddenOverlays();
+    applyLayerVisibility(map, layerVisibilityStore.state);
+    applyLineWidthFactors(map, lineWidthStore.factors);
+    hiddenSync.syncAll();
+  });
   presetStandardBtn.setAttribute("aria-pressed", String(next === "standard"));
   presetMonoBtn.setAttribute("aria-pressed", String(next === "mono"));
 }


### PR DESCRIPTION
## Summary

モノトーン preset に切り替えると、選択状態の橙色オーバレイが完全に見えなくなる問題を修正。

- **原因**: `map.setStyle(style, { diff: true })` は preset 切替時に custom source / layer（`selection-overlay` / `highlight-overlay`）を全て削除する。その後の `styledata` は `isStyleLoaded()=false` で 1 回発火して終わり、`true` 版が追加発火しないケースがある（mono 切替時の 2 秒観察で `isStyleLoaded=true` な `styledata` は 0 回）。既存の `styledata` ハンドラは `isStyleLoaded` ガードで早期 return していたため、overlay 再構築が走らず source レベルで欠落したまま放置されていた。
- **修正**: `applyPreset` 内の `setStyle` 直後に `map.once("idle", …)` を追加し、style が落ち着いた 1 度きりのタイミングで `refreshNonHiddenOverlays` / `applyLayerVisibility` / `applyLineWidthFactors` / `hiddenSync.syncAll` を再適用する。`idle` は確実に `isStyleLoaded()=true` で発火するため、ガードによる早期 return を回避できる。
- **version**: `0.2.0` → `0.3.0` に bump。ヘッダに `v0.3.0` が表示されることで新ビルドであることを識別できる。

## 変更ファイル

- `src/main.ts` ([applyPreset](src/main.ts#L275))
- `package.json`（version bump）

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test`（109 件グリーン）
- [x] `pnpm e2e`（13 件グリーン — preset 切替と選択の既存挙動が壊れていないことを確認）
- [x] `pnpm build`（production build 成功）
- [x] 実ブラウザ: standard でクリック→mono 切替後も `selection-overlay` source / layer が維持され、selection の橙縁取りが継続して見える。source の feature 数も 1 件のまま保持。

## 残件

`highlight-overlay`（「強調」ボタンで赤く塗る機能）は PR #28 の仕様どおり preset 連動（standard=赤 / mono=黒）のまま据え置き。こちらも固定色にしたい場合は別 issue。

🤖 Generated with [Claude Code](https://claude.com/claude-code)