### PR TITLE
feat: 「選択以外を削除」アクション (#33) (v0.4.0)

### DIFF
--- a/index.html
+++ b/index.html
@@ -252,6 +252,7 @@
           <button id="redo" class="primary" type="button" title="やり直す (⇧⌘Z)" disabled>やり直す</button>
           <button id="highlight" class="primary" type="button" title="選択中を強調／解除" disabled>強調</button>
           <button id="delete" class="primary" type="button" title="選択中を削除 (Delete)" disabled>削除</button>
+          <button id="delete-inverse" class="primary" type="button" title="選択した feature の周囲（4倍領域）にある未選択要素を削除" disabled>選択以外を削除</button>
           <button id="reset-edits" class="primary" type="button" title="編集を全て破棄" disabled>
             編集をリセット
           </button>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "map-simplifier",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,6 +21,12 @@ import {
   type ProjectFn,
 } from "./map/featureDistance";
 import {
+  expandBoundsByFactor,
+  geometryBounds,
+  unionBounds,
+  type LngLatBounds,
+} from "./map/featureBounds";
+import {
   LINE_WIDTH_CATEGORIES,
   LineWidthStore,
   LINE_WIDTH_MAX,
@@ -66,6 +72,7 @@ const undoBtn = requireEl("undo", HTMLButtonElement);
 const redoBtn = requireEl("redo", HTMLButtonElement);
 const highlightBtn = requireEl("highlight", HTMLButtonElement);
 const deleteBtn = requireEl("delete", HTMLButtonElement);
+const deleteInverseBtn = requireEl("delete-inverse", HTMLButtonElement);
 const resetEditsBtn = requireEl("reset-edits", HTMLButtonElement);
 const selectionCountEl = requireEl("selection-count", HTMLSpanElement);
 const layerVisibilityToggle = requireEl("layer-visibility-toggle", HTMLButtonElement);
@@ -245,6 +252,7 @@ function updateSelectionUI(): void {
     ),
   );
   deleteBtn.disabled = n === 0;
+  deleteInverseBtn.disabled = n < 2;
   highlightBtn.disabled = n === 0;
 }
 selectionStore.subscribe(() => updateSelectionUI());
@@ -407,6 +415,62 @@ function deleteSelected(): void {
   history.push(before);
 }
 
+// 選択 feature を包む lng-lat BBox A の中心を保ったまま辺を 2 倍（面積 4 倍）にした
+// BBox B を作り、B 内の hideable feature のうち選択以外を一括 hidden にする。#33
+// 4 倍は経験的に「残したい対象の周辺」を示す妥当な広さ。実運用で要調整。
+const INVERSE_DELETE_BOUNDS_LINEAR_FACTOR = 2;
+
+function deleteInverseOfSelected(): void {
+  const items = selectionStore.state;
+  if (items.length < 2) return;
+
+  const itemBounds: LngLatBounds[] = [];
+  for (const i of items) {
+    const b = geometryBounds(i.geometry);
+    if (b) itemBounds.push(b);
+  }
+  const a = unionBounds(itemBounds);
+  if (!a) return;
+  const b = expandBoundsByFactor(a, INVERSE_DELETE_BOUNDS_LINEAR_FACTOR);
+
+  // lng-lat の B を screen 座標 AABB に project（緯度は y が反転するので min/max を取る）。
+  const p1 = map.project([b[0], b[1]]);
+  const p2 = map.project([b[2], b[3]]);
+  const screenBbox: [[number, number], [number, number]] = [
+    [Math.min(p1.x, p2.x), Math.min(p1.y, p2.y)],
+    [Math.max(p1.x, p2.x), Math.max(p1.y, p2.y)],
+  ];
+  const raw = map.queryRenderedFeatures(screenBbox, {
+    layers: [...HIDEABLE_LAYER_IDS],
+  });
+
+  const selectedKeys = new Set(
+    items.map((i) => `${i.sourceLayer}::${JSON.stringify(i.geometry)}`),
+  );
+  const seen = new Set<string>();
+  const targets: { sourceLayer: string; geometry: import("geojson").Geometry; properties: Record<string, unknown> }[] = [];
+  for (const f of raw) {
+    const sourceLayer = f.sourceLayer ?? "";
+    const k = `${sourceLayer}::${JSON.stringify(f.geometry)}`;
+    if (selectedKeys.has(k)) continue;
+    if (seen.has(k)) continue;
+    seen.add(k);
+    if (!isSourceLayerVisible(sourceLayer, layerVisibilityStore.state)) continue;
+    if (editState.isHidden({ sourceLayer, geometry: f.geometry })) continue;
+    targets.push({
+      sourceLayer,
+      geometry: f.geometry,
+      properties: f.properties ?? {},
+    });
+  }
+
+  if (targets.length === 0) return;
+  const before = editState.snapshot();
+  editState.hideMany(targets);
+  // 選択は維持。「選択した対象を残し、それ以外を消す」機能なので選択クリアは不要。
+  history.push(before);
+}
+
 // 選択中の全 feature に強調を適用。すでに全員強調されている場合は解除。
 // 混在時（一部強調・一部未強調）は「未強調のものを全て強調」で揃える。
 function toggleHighlightSelected(): void {
@@ -442,6 +506,7 @@ function redo(): void {
 }
 
 deleteBtn.addEventListener("click", deleteSelected);
+deleteInverseBtn.addEventListener("click", deleteInverseOfSelected);
 highlightBtn.addEventListener("click", toggleHighlightSelected);
 resetEditsBtn.addEventListener("click", resetAllEdits);
 undoBtn.addEventListener("click", undo);

--- a/src/map/featureBounds.ts
+++ b/src/map/featureBounds.ts
@@ -1,0 +1,98 @@
+import type { Geometry, Position } from "geojson";
+
+/**
+ * GSI 由来の feature 群の経度緯度 BBox を扱う純関数群。#33
+ *
+ * - `geometryBounds`: 単一 geometry の lng-lat 範囲。
+ * - `unionBounds`: 複数 BBox の合成。
+ * - `expandBoundsByFactor`: 中心を保ったまま縦横を `factor` 倍に拡張。
+ *   factor=2 のとき面積 4 倍（辺は各 2 倍）。
+ */
+
+export type LngLatBounds = readonly [number, number, number, number]; // [minLng, minLat, maxLng, maxLat]
+
+function extendByPosition(b: number[], p: Position): void {
+  const lng = p[0]!;
+  const lat = p[1]!;
+  if (lng < b[0]!) b[0] = lng;
+  if (lat < b[1]!) b[1] = lat;
+  if (lng > b[2]!) b[2] = lng;
+  if (lat > b[3]!) b[3] = lat;
+}
+
+function extendByPositions(b: number[], coords: Position[]): void {
+  for (const c of coords) extendByPosition(b, c);
+}
+
+/** 単一 geometry の lng-lat BBox。空 / 不明な geometry は null。 */
+export function geometryBounds(g: Geometry): LngLatBounds | null {
+  const b = [Infinity, Infinity, -Infinity, -Infinity];
+  switch (g.type) {
+    case "Point":
+      extendByPosition(b, g.coordinates);
+      break;
+    case "MultiPoint":
+    case "LineString":
+      extendByPositions(b, g.coordinates);
+      break;
+    case "MultiLineString":
+    case "Polygon":
+      for (const line of g.coordinates) extendByPositions(b, line);
+      break;
+    case "MultiPolygon":
+      for (const poly of g.coordinates) {
+        for (const ring of poly) extendByPositions(b, ring);
+      }
+      break;
+    case "GeometryCollection": {
+      let any = false;
+      for (const child of g.geometries) {
+        const cb = geometryBounds(child);
+        if (!cb) continue;
+        any = true;
+        if (cb[0] < b[0]!) b[0] = cb[0];
+        if (cb[1] < b[1]!) b[1] = cb[1];
+        if (cb[2] > b[2]!) b[2] = cb[2];
+        if (cb[3] > b[3]!) b[3] = cb[3];
+      }
+      if (!any) return null;
+      break;
+    }
+    default:
+      return null;
+  }
+  if (!Number.isFinite(b[0]) || !Number.isFinite(b[2])) return null;
+  return [b[0]!, b[1]!, b[2]!, b[3]!] as const;
+}
+
+/** 複数 BBox の合成（min/min/max/max）。空配列なら null。 */
+export function unionBounds(list: ReadonlyArray<LngLatBounds>): LngLatBounds | null {
+  if (list.length === 0) return null;
+  let minLng = Infinity;
+  let minLat = Infinity;
+  let maxLng = -Infinity;
+  let maxLat = -Infinity;
+  for (const b of list) {
+    if (b[0] < minLng) minLng = b[0];
+    if (b[1] < minLat) minLat = b[1];
+    if (b[2] > maxLng) maxLng = b[2];
+    if (b[3] > maxLat) maxLat = b[3];
+  }
+  return [minLng, minLat, maxLng, maxLat] as const;
+}
+
+/**
+ * 中心を保ったまま縦横を `factor` 倍に拡張した BBox。
+ * factor=1 で同じ、factor=2 で各辺 2 倍（面積 4 倍）。
+ *
+ * 退化 BBox（点や線で width/height が 0）の場合も中心を保つだけで増えない。
+ * 必要なら呼び出し側で min size を加える。
+ */
+export function expandBoundsByFactor(b: LngLatBounds, factor: number): LngLatBounds {
+  const [minLng, minLat, maxLng, maxLat] = b;
+  const cx = (minLng + maxLng) / 2;
+  const cy = (minLat + maxLat) / 2;
+  const halfW = ((maxLng - minLng) * factor) / 2;
+  const halfH = ((maxLat - minLat) * factor) / 2;
+  return [cx - halfW, cy - halfH, cx + halfW, cy + halfH] as const;
+}

--- a/tests/e2e/display-and-export.spec.ts
+++ b/tests/e2e/display-and-export.spec.ts
@@ -833,6 +833,93 @@ test("shift+drag rubber band selects multiple features", async ({ page }) => {
   expect(selected).toBeGreaterThan(1);
 });
 
+test("select multiple → 「選択以外を削除」 hides surrounding features and undo restores", async ({ page }) => {
+  await page.goto("/");
+  await page.waitForFunction(() => document.body.dataset.mapReady === "true", null, {
+    timeout: 30_000,
+  });
+  await page.evaluate(() => {
+    const g = window as unknown as { __mlMap?: { setZoom(z: number): void } };
+    g.__mlMap?.setZoom(15);
+  });
+  await page.waitForFunction(
+    () => {
+      const g = window as unknown as {
+        __mlMap?: { getZoom(): number; isStyleLoaded(): boolean; areTilesLoaded(): boolean };
+      };
+      return (
+        !!g.__mlMap &&
+        Math.round(g.__mlMap.getZoom()) === 15 &&
+        g.__mlMap.isStyleLoaded() &&
+        g.__mlMap.areTilesLoaded()
+      );
+    },
+    null,
+    { timeout: 15_000 },
+  );
+
+  // 中央の小さい矩形で 2 件以上を選択
+  const selectedCount = await page.evaluate(() => {
+    const canvas = document.querySelector(".maplibregl-canvas") as HTMLElement;
+    const rect = canvas.getBoundingClientRect();
+    const cx = canvas.clientWidth / 2;
+    const cy = canvas.clientHeight / 2;
+    const size = 80;
+    const p1 = { x: cx - size / 2, y: cy - size / 2 };
+    const p2 = { x: cx + size / 2, y: cy + size / 2 };
+    function mk(type: string, x: number, y: number): MouseEvent {
+      return new MouseEvent(type, {
+        bubbles: true,
+        cancelable: true,
+        view: window,
+        clientX: rect.left + x,
+        clientY: rect.top + y,
+        button: 0,
+        shiftKey: true,
+      });
+    }
+    canvas.dispatchEvent(mk("mousedown", p1.x, p1.y));
+    canvas.dispatchEvent(mk("mousemove", (p1.x + p2.x) / 2, (p1.y + p2.y) / 2));
+    canvas.dispatchEvent(mk("mousemove", p2.x, p2.y));
+    canvas.dispatchEvent(mk("mouseup", p2.x, p2.y));
+    const g = window as unknown as { __selectionStore?: { state: unknown[] } };
+    return g.__selectionStore?.state.length ?? 0;
+  });
+  expect(selectedCount).toBeGreaterThan(1);
+
+  // 「選択以外を削除」ボタンを押下
+  const inverseBtn = page.locator("#delete-inverse");
+  await expect(inverseBtn).toBeEnabled();
+
+  const hiddenBefore = await page.evaluate(() => {
+    const g = window as unknown as { __editState?: { state: { hidden: unknown[] } } };
+    return g.__editState?.state.hidden.length ?? 0;
+  });
+
+  await inverseBtn.click();
+
+  const hiddenAfter = await page.evaluate(() => {
+    const g = window as unknown as { __editState?: { state: { hidden: unknown[] } } };
+    return g.__editState?.state.hidden.length ?? 0;
+  });
+  expect(hiddenAfter).toBeGreaterThan(hiddenBefore);
+
+  // 選択は維持されている（クリアされない仕様）
+  const selectedAfter = await page.evaluate(() => {
+    const g = window as unknown as { __selectionStore?: { state: unknown[] } };
+    return g.__selectionStore?.state.length ?? 0;
+  });
+  expect(selectedAfter).toBe(selectedCount);
+
+  // Undo で hidden が元に戻る
+  await page.locator("#undo").click();
+  const hiddenAfterUndo = await page.evaluate(() => {
+    const g = window as unknown as { __editState?: { state: { hidden: unknown[] } } };
+    return g.__editState?.state.hidden.length ?? 0;
+  });
+  expect(hiddenAfterUndo).toBe(hiddenBefore);
+});
+
 test("layer popover combines visibility and per-layer line width controls", async ({ page }) => {
   await page.goto("/");
   await page.waitForFunction(() => document.body.dataset.mapReady === "true", null, {

--- a/tests/unit/featureBounds.test.ts
+++ b/tests/unit/featureBounds.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+import type { Geometry } from "geojson";
+import {
+  expandBoundsByFactor,
+  geometryBounds,
+  unionBounds,
+  type LngLatBounds,
+} from "../../src/map/featureBounds";
+
+describe("geometryBounds", () => {
+  it("Point", () => {
+    expect(geometryBounds({ type: "Point", coordinates: [10, 20] })).toEqual([10, 20, 10, 20]);
+  });
+
+  it("LineString", () => {
+    const g: Geometry = { type: "LineString", coordinates: [[0, 0], [3, 4], [-1, 2]] };
+    expect(geometryBounds(g)).toEqual([-1, 0, 3, 4]);
+  });
+
+  it("Polygon は exterior ring を含む全 ring から", () => {
+    const g: Geometry = {
+      type: "Polygon",
+      coordinates: [
+        [[0, 0], [10, 0], [10, 10], [0, 10], [0, 0]],
+      ],
+    };
+    expect(geometryBounds(g)).toEqual([0, 0, 10, 10]);
+  });
+
+  it("MultiLineString", () => {
+    const g: Geometry = {
+      type: "MultiLineString",
+      coordinates: [
+        [[0, 0], [5, 5]],
+        [[-3, 1], [4, -2]],
+      ],
+    };
+    expect(geometryBounds(g)).toEqual([-3, -2, 5, 5]);
+  });
+
+  it("MultiPolygon は全 polygon の全 ring から", () => {
+    const g: Geometry = {
+      type: "MultiPolygon",
+      coordinates: [
+        [[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]],
+        [[[10, 10], [11, 10], [11, 11], [10, 11], [10, 10]]],
+      ],
+    };
+    expect(geometryBounds(g)).toEqual([0, 0, 11, 11]);
+  });
+
+  it("GeometryCollection は子の合成", () => {
+    const g: Geometry = {
+      type: "GeometryCollection",
+      geometries: [
+        { type: "Point", coordinates: [0, 0] },
+        { type: "Point", coordinates: [5, -3] },
+      ],
+    };
+    expect(geometryBounds(g)).toEqual([0, -3, 5, 0]);
+  });
+});
+
+describe("unionBounds", () => {
+  it("空配列は null", () => {
+    expect(unionBounds([])).toBeNull();
+  });
+
+  it("複数 BBox の min/max", () => {
+    const a: LngLatBounds = [0, 0, 10, 10];
+    const b: LngLatBounds = [-5, 3, 8, 20];
+    expect(unionBounds([a, b])).toEqual([-5, 0, 10, 20]);
+  });
+});
+
+describe("expandBoundsByFactor", () => {
+  it("factor=1 は同じ BBox", () => {
+    const b: LngLatBounds = [0, 0, 10, 10];
+    expect(expandBoundsByFactor(b, 1)).toEqual([0, 0, 10, 10]);
+  });
+
+  it("factor=2 は中心を保ったまま各辺 2 倍（面積 4 倍）", () => {
+    const b: LngLatBounds = [0, 0, 10, 10];
+    expect(expandBoundsByFactor(b, 2)).toEqual([-5, -5, 15, 15]);
+  });
+
+  it("非対称な BBox でも中心を保つ", () => {
+    const b: LngLatBounds = [10, 20, 14, 30]; // center (12, 25), w=4, h=10
+    // factor=2 → halfW=4, halfH=10 → (8,15)-(16,35)
+    expect(expandBoundsByFactor(b, 2)).toEqual([8, 15, 16, 35]);
+  });
+
+  it("退化 BBox（点）は factor によらず点のまま", () => {
+    const b: LngLatBounds = [5, 5, 5, 5];
+    expect(expandBoundsByFactor(b, 4)).toEqual([5, 5, 5, 5]);
+  });
+});


### PR DESCRIPTION
Closes #33

## Summary

複数選択中の feature を残し、その周辺（選択 BBox の中心を保ったまま辺長 2 倍 = 面積 4 倍に拡張した領域）にある **未選択 feature を一括で非表示** にするアクションを追加。書籍図版作成で「残したい対象を選んだ後の周辺整理」を一手でやれるようにする。

## 変更内容

- **`src/map/featureBounds.ts`** (新規): `geometryBounds(g)` / `unionBounds(list)` / `expandBoundsByFactor(b, factor)` の純関数。Point / Line / Polygon / Multi* / GeometryCollection 対応。
- **`src/main.ts`**: `deleteInverseOfSelected()` を追加（[main.ts](src/main.ts)）。
  - 選択 feature の lng-lat BBox を `unionBounds` で合成 → `expandBoundsByFactor(_, 2)` で辺 2 倍 / 面積 4 倍に拡張
  - lng-lat の B を `map.project` で screen 座標 AABB に変換し `queryRenderedFeatures` で候補列挙
  - 選択中 / hidden 済み / 非表示カテゴリを除外
  - `editState.hideMany` で一括 hidden 化、`history.push(before)` で Undo 1 ステップに乗せる
  - 選択は維持（クリアしない）
- **`index.html`**: 「選択以外を削除」ボタンを「削除」の右に追加。disabled 条件は選択件数 < 2。
- **`tests/unit/featureBounds.test.ts`** (新規): 12 件。
- **`tests/e2e/display-and-export.spec.ts`**: 矩形選択 → 「選択以外を削除」→ hidden 増加 → 選択維持 → Undo で復元、までを 1 シナリオで検証。
- **`package.json`**: `0.3.0` → `0.4.0`。

## 実運用での挙動メモ

ズーム 15 / 中央 80px の矩形選択で 49 件選択 → ボタン押下で hidden が 4569 件まで増加（4倍領域内の建物 polygon・道路 line を一括 hide）→ Undo で 0 件に復元、を実機で確認。倍率 4 が広いか狭いかは触ってみての調整余地あり。

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test`（121 件、新規 12 含む）
- [x] `pnpm e2e`（14 件、新規 1 含む）
- [x] `pnpm build`
- [x] 実ブラウザで矩形選択 → 「選択以外を削除」→ Undo の往復確認、ヘッダ `v0.4.0` 表示確認

## スコープ外

- 倍率（辺 2 / 面積 4）のユーザー調整 UI — 実運用で値が決まったら別 issue。
- viewport 外の feature を含める拡張（`queryRenderedFeatures` の制約をそのまま受容）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)