### PR TITLE
feat: 編集中ズームロック + ズーム表示 + 選択以外を削除の partial 除外 (#35) (v0.5.0)

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,11 +23,12 @@
       header {
         display: flex;
         align-items: center;
-        flex-wrap: wrap;
+        flex-wrap: nowrap;
         gap: 12px;
         padding: 8px 12px;
         border-bottom: 1px solid #e0e0e0;
         background: #fff;
+        overflow-x: auto;
       }
       header h1 {
         margin: 0;
@@ -94,6 +95,16 @@
         color: #666;
         min-width: 6em;
         text-align: right;
+      }
+      .zoom-display {
+        font-size: 12px;
+        color: #666;
+        font-variant-numeric: tabular-nums;
+        white-space: nowrap;
+      }
+      .zoom-display[data-locked="true"] {
+        color: #b42318;
+        font-weight: 600;
       }
       button.primary {
         appearance: none;
@@ -243,6 +254,7 @@
         </form>
         <span id="selection-count" class="selection-count" aria-live="polite"></span>
         <span class="spacer"></span>
+        <span id="zoom-display" class="zoom-display" aria-live="polite" title="現在のズームレベル。編集中はロックされ、🔒 が表示される。">Z --</span>
         <div class="preset-group" role="group" aria-label="スタイルプリセット">
           <button id="preset-standard" type="button" aria-pressed="true">標準</button>
           <button id="preset-mono" type="button" aria-pressed="false">モノトーン</button>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "map-simplifier",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "map-simplifier",
-  "version": "0.5.0",
+  "version": "0.5.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/main.ts
+++ b/src/main.ts
@@ -490,6 +490,14 @@ function deleteInverseOfSelected(): void {
   const selectedKeys = new Set(
     items.map((i) => `${i.sourceLayer}::${JSON.stringify(i.geometry)}`),
   );
+  // partial 保護のキー：同 sourceLayer + properties 完全一致なら、たとえ geometry が
+  // 別タイルの partial として返ってきていても「同じ論理 feature」とみなして除外する。
+  // GSI ベクトルタイルでは partial 同士は properties (vt_code 等) が完全一致するため
+  // 実用上ほぼ確実に同一性判定できる。実機検証では 88 件選択に対し 1228 件の partial が
+  // この経路で誤って hidden に登録されていた（#35）。
+  const selectedPropsKeys = new Set(
+    items.map((i) => `${i.sourceLayer}::${JSON.stringify(i.properties)}`),
+  );
   const seen = new Set<string>();
   const targets: { sourceLayer: string; geometry: import("geojson").Geometry; properties: Record<string, unknown> }[] = [];
   for (const f of raw) {
@@ -501,8 +509,7 @@ function deleteInverseOfSelected(): void {
     if (!isSourceLayerVisible(sourceLayer, layerVisibilityStore.state)) continue;
     if (editState.isHidden({ sourceLayer, geometry: f.geometry })) continue;
 
-    // partial 保護：candidate の bbox 中心が同じ sourceLayer の選択 BBox に含まれるなら
-    // 選択 feature の partial 部分とみなして除外。
+    // partial 保護 1: candidate の bbox 中心が同じ sourceLayer の選択 BBox に含まれるなら除外。
     const cb = geometryBounds(f.geometry);
     if (cb) {
       const center = centerOfBounds(cb);
@@ -511,6 +518,12 @@ function deleteInverseOfSelected(): void {
         continue;
       }
     }
+
+    // partial 保護 2: 選択 feature と sourceLayer + properties が一致する candidate は
+    // 「同じ論理 feature の partial」とみなして除外。タイル境界で分割されて bbox 範囲外に
+    // 出ている partial も保護できる。
+    const propsKey = `${sourceLayer}::${JSON.stringify(f.properties ?? {})}`;
+    if (selectedPropsKeys.has(propsKey)) continue;
 
     targets.push({
       sourceLayer,

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,11 +21,14 @@ import {
   type ProjectFn,
 } from "./map/featureDistance";
 import {
+  centerOfBounds,
   expandBoundsByFactor,
   geometryBounds,
+  pointInBounds,
   unionBounds,
   type LngLatBounds,
 } from "./map/featureBounds";
+import { formatZoomDisplay, lockZoom, unlockZoom, type ZoomLockSnapshot } from "./map/zoomLock";
 import {
   LINE_WIDTH_CATEGORIES,
   LineWidthStore,
@@ -79,6 +82,7 @@ const layerVisibilityToggle = requireEl("layer-visibility-toggle", HTMLButtonEle
 const layerVisibilityPopover = requireEl("layer-visibility-popover", HTMLElement);
 const lineWidthResetBtn = requireEl("line-width-reset", HTMLButtonElement);
 const appVersionEl = requireEl("app-version", HTMLSpanElement);
+const zoomDisplayEl = requireEl("zoom-display", HTMLSpanElement);
 
 // Vite の define で package.json.version から注入される。
 appVersionEl.textContent = `v${__APP_VERSION__}`;
@@ -199,6 +203,7 @@ map.on("load", () => {
   applyLayerVisibility(map, layerVisibilityStore.state);
   applyLineWidthFactors(map, lineWidthStore.factors);
   hiddenSync.syncAll();
+  updateZoomDisplay();
   document.body.dataset["mapReady"] = "true";
 });
 
@@ -226,6 +231,33 @@ map.on("idle", () => {
   hiddenSync.syncAll();
 });
 
+// 編集中（hidden / highlighted のいずれかが非空）はズームを現行に固定する。#35
+// GSI タイルにはグローバル feature ID が無く、ズーム間で feature の geometry が
+// 別物に simplify されるため、ズーム変更は editState の追跡を破壊する。
+let zoomLockSnapshot: ZoomLockSnapshot | null = null;
+
+function isEditingActive(): boolean {
+  const s = editState.state;
+  return s.hidden.length > 0 || s.highlighted.length > 0;
+}
+
+function refreshZoomLock(): void {
+  const editing = isEditingActive();
+  if (editing && zoomLockSnapshot === null) {
+    zoomLockSnapshot = lockZoom(map);
+  } else if (!editing && zoomLockSnapshot !== null) {
+    unlockZoom(map, zoomLockSnapshot);
+    zoomLockSnapshot = null;
+  }
+  updateZoomDisplay();
+}
+
+function updateZoomDisplay(): void {
+  const locked = zoomLockSnapshot !== null;
+  zoomDisplayEl.textContent = formatZoomDisplay(map.getZoom(), locked);
+  zoomDisplayEl.dataset["locked"] = locked ? "true" : "false";
+}
+
 editState.subscribe((s) => {
   setHighlightOverlayData(
     map,
@@ -237,8 +269,11 @@ editState.subscribe((s) => {
   );
   hiddenSync.syncAll();
   resetEditsBtn.disabled = s.hidden.length === 0 && s.highlighted.length === 0;
+  refreshZoomLock();
 });
 resetEditsBtn.disabled = true;
+map.on("zoom", updateZoomDisplay);
+map.on("zoomend", updateZoomDisplay);
 
 function updateSelectionUI(): void {
   const n = selectionStore.state.length;
@@ -424,10 +459,18 @@ function deleteInverseOfSelected(): void {
   const items = selectionStore.state;
   if (items.length < 2) return;
 
+  // 選択 feature ごとの (sourceLayer, BBox) を保持しておく。
+  // タイル境界で同じ論理 feature が partial 別 geometry として返ってくるケースで、
+  // 「sourceLayer 一致 + 中心点が選択 BBox 内」のものを除外して保護する（#35）。
+  const selectedBoundsByLayer = new Map<string, LngLatBounds[]>();
   const itemBounds: LngLatBounds[] = [];
   for (const i of items) {
     const b = geometryBounds(i.geometry);
-    if (b) itemBounds.push(b);
+    if (!b) continue;
+    itemBounds.push(b);
+    const list = selectedBoundsByLayer.get(i.sourceLayer);
+    if (list) list.push(b);
+    else selectedBoundsByLayer.set(i.sourceLayer, [b]);
   }
   const a = unionBounds(itemBounds);
   if (!a) return;
@@ -457,6 +500,18 @@ function deleteInverseOfSelected(): void {
     seen.add(k);
     if (!isSourceLayerVisible(sourceLayer, layerVisibilityStore.state)) continue;
     if (editState.isHidden({ sourceLayer, geometry: f.geometry })) continue;
+
+    // partial 保護：candidate の bbox 中心が同じ sourceLayer の選択 BBox に含まれるなら
+    // 選択 feature の partial 部分とみなして除外。
+    const cb = geometryBounds(f.geometry);
+    if (cb) {
+      const center = centerOfBounds(cb);
+      const protectList = selectedBoundsByLayer.get(sourceLayer);
+      if (protectList && protectList.some((pb) => pointInBounds(center, pb))) {
+        continue;
+      }
+    }
+
     targets.push({
       sourceLayer,
       geometry: f.geometry,

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,13 +21,17 @@ import {
   type ProjectFn,
 } from "./map/featureDistance";
 import {
-  centerOfBounds,
   expandBoundsByFactor,
   geometryBounds,
-  pointInBounds,
   unionBounds,
   type LngLatBounds,
 } from "./map/featureBounds";
+import {
+  featureGeometryKey,
+  protectedFeatureKeysForInverseDelete,
+  sourceTileZoomCandidates,
+  type FeatureIdentityInput,
+} from "./map/featureIdentity";
 import { formatZoomDisplay, lockZoom, unlockZoom, type ZoomLockSnapshot } from "./map/zoomLock";
 import {
   LINE_WIDTH_CATEGORIES,
@@ -459,78 +463,56 @@ function deleteInverseOfSelected(): void {
   const items = selectionStore.state;
   if (items.length < 2) return;
 
-  // 選択 feature ごとの (sourceLayer, BBox) を保持しておく。
-  // タイル境界で同じ論理 feature が partial 別 geometry として返ってくるケースで、
-  // 「sourceLayer 一致 + 中心点が選択 BBox 内」のものを除外して保護する（#35）。
-  const selectedBoundsByLayer = new Map<string, LngLatBounds[]>();
   const itemBounds: LngLatBounds[] = [];
   for (const i of items) {
     const b = geometryBounds(i.geometry);
     if (!b) continue;
     itemBounds.push(b);
-    const list = selectedBoundsByLayer.get(i.sourceLayer);
-    if (list) list.push(b);
-    else selectedBoundsByLayer.set(i.sourceLayer, [b]);
   }
   const a = unionBounds(itemBounds);
   if (!a) return;
   const b = expandBoundsByFactor(a, INVERSE_DELETE_BOUNDS_LINEAR_FACTOR);
 
-  // lng-lat の B を screen 座標 AABB に project（緯度は y が反転するので min/max を取る）。
-  const p1 = map.project([b[0], b[1]]);
-  const p2 = map.project([b[2], b[3]]);
+  // lng-lat の B の 4 隅を screen 座標 AABB に project。
+  // bearing/pitch がある場合、対角 2 点だけでは過小評価するため 4 隅を使う（#33）。
+  const corners = [
+    map.project([b[0], b[1]]),
+    map.project([b[0], b[3]]),
+    map.project([b[2], b[1]]),
+    map.project([b[2], b[3]]),
+  ];
   const screenBbox: [[number, number], [number, number]] = [
-    [Math.min(p1.x, p2.x), Math.min(p1.y, p2.y)],
-    [Math.max(p1.x, p2.x), Math.max(p1.y, p2.y)],
+    [Math.min(...corners.map((p) => p.x)), Math.min(...corners.map((p) => p.y))],
+    [Math.max(...corners.map((p) => p.x)), Math.max(...corners.map((p) => p.y))],
   ];
   const raw = map.queryRenderedFeatures(screenBbox, {
     layers: [...HIDEABLE_LAYER_IDS],
   });
 
-  const selectedKeys = new Set(
-    items.map((i) => `${i.sourceLayer}::${JSON.stringify(i.geometry)}`),
-  );
-  // partial 保護のキー：同 sourceLayer + properties 完全一致なら、たとえ geometry が
-  // 別タイルの partial として返ってきていても「同じ論理 feature」とみなして除外する。
-  // GSI ベクトルタイルでは partial 同士は properties (vt_code 等) が完全一致するため
-  // 実用上ほぼ確実に同一性判定できる。実機検証では 88 件選択に対し 1228 件の partial が
-  // この経路で誤って hidden に登録されていた（#35）。
-  const selectedPropsKeys = new Set(
-    items.map((i) => `${i.sourceLayer}::${JSON.stringify(i.properties)}`),
-  );
   const seen = new Set<string>();
-  const targets: { sourceLayer: string; geometry: import("geojson").Geometry; properties: Record<string, unknown> }[] = [];
+  const candidates: FeatureIdentityInput[] = [];
   for (const f of raw) {
     const sourceLayer = f.sourceLayer ?? "";
-    const k = `${sourceLayer}::${JSON.stringify(f.geometry)}`;
-    if (selectedKeys.has(k)) continue;
+    const candidate: FeatureIdentityInput = {
+      sourceLayer,
+      geometry: f.geometry,
+      properties: f.properties ?? {},
+    };
+    const k = featureGeometryKey(candidate);
     if (seen.has(k)) continue;
     seen.add(k);
     if (!isSourceLayerVisible(sourceLayer, layerVisibilityStore.state)) continue;
     if (editState.isHidden({ sourceLayer, geometry: f.geometry })) continue;
-
-    // partial 保護 1: candidate の bbox 中心が同じ sourceLayer の選択 BBox に含まれるなら除外。
-    const cb = geometryBounds(f.geometry);
-    if (cb) {
-      const center = centerOfBounds(cb);
-      const protectList = selectedBoundsByLayer.get(sourceLayer);
-      if (protectList && protectList.some((pb) => pointInBounds(center, pb))) {
-        continue;
-      }
-    }
-
-    // partial 保護 2: 選択 feature と sourceLayer + properties が一致する candidate は
-    // 「同じ論理 feature の partial」とみなして除外。タイル境界で分割されて bbox 範囲外に
-    // 出ている partial も保護できる。
-    const propsKey = `${sourceLayer}::${JSON.stringify(f.properties ?? {})}`;
-    if (selectedPropsKeys.has(propsKey)) continue;
-
-    targets.push({
-      sourceLayer,
-      geometry: f.geometry,
-      properties: f.properties ?? {},
-    });
+    candidates.push(candidate);
   }
+
+  const protectedKeys = protectedFeatureKeysForInverseDelete({
+    selected: items,
+    candidates,
+    project: (lng, lat) => map.project([lng, lat]),
+    sourceZooms: sourceTileZoomCandidates(map.getZoom()),
+  });
+  const targets = candidates.filter((f) => !protectedKeys.has(featureGeometryKey(f)));
 
   if (targets.length === 0) return;
   const before = editState.snapshot();

--- a/src/map/featureBounds.ts
+++ b/src/map/featureBounds.ts
@@ -96,3 +96,13 @@ export function expandBoundsByFactor(b: LngLatBounds, factor: number): LngLatBou
   const halfH = ((maxLat - minLat) * factor) / 2;
   return [cx - halfW, cy - halfH, cx + halfW, cy + halfH] as const;
 }
+
+/** BBox の中心点 [lng, lat]。 */
+export function centerOfBounds(b: LngLatBounds): readonly [number, number] {
+  return [(b[0] + b[2]) / 2, (b[1] + b[3]) / 2] as const;
+}
+
+/** 点が BBox 内（境界含む）にあるか。 */
+export function pointInBounds(p: readonly [number, number], b: LngLatBounds): boolean {
+  return p[0] >= b[0] && p[0] <= b[2] && p[1] >= b[1] && p[1] <= b[3];
+}

--- a/src/map/featureIdentity.ts
+++ b/src/map/featureIdentity.ts
@@ -1,0 +1,423 @@
+import type { Geometry, Position } from "geojson";
+import {
+  pointToSegmentDistance,
+  type ProjectFn,
+  type ScreenPoint,
+} from "./featureDistance";
+
+/**
+ * 「選択以外を削除」で、選択 feature と同じ論理 feature のタイル分割片だけを保護する。
+ *
+ * properties 完全一致だけでは `BldA { vt_code: 3111 }` のような汎用属性を持つ
+ * 無関係な建物まで保護してしまうため、同一属性に加えて「現在の source tile 境界上で
+ * geometry が接続している」ことを条件にする。
+ */
+
+export interface FeatureIdentityInput {
+  sourceLayer: string;
+  geometry: Geometry;
+  properties: Record<string, unknown>;
+}
+
+interface ScreenBounds {
+  minX: number;
+  minY: number;
+  maxX: number;
+  maxY: number;
+}
+
+interface ProjectedPoint extends ScreenPoint {
+  nearTileBoundary: boolean;
+}
+
+interface ProjectedPath {
+  points: ProjectedPoint[];
+}
+
+interface ProjectedGeometry {
+  bounds: ScreenBounds | null;
+  hasTileBoundaryPoint: boolean;
+  paths: ProjectedPath[];
+}
+
+interface FeatureDescriptor {
+  key: string;
+  propsKey: string;
+  projected: ProjectedGeometry;
+}
+
+export const PARTIAL_PROTECTION_MARGIN_PX = 4;
+const TILE_BOUNDARY_EPSILON = 0.001;
+const GSI_SOURCE_MIN_ZOOM = 4;
+const GSI_SOURCE_MAX_ZOOM = 16;
+
+export function stableStringify(value: unknown): string {
+  if (value === undefined) return "undefined";
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value) ?? String(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map((v) => stableStringify(v)).join(",")}]`;
+  }
+
+  const object = value as Record<string, unknown>;
+  const pairs = Object.keys(object)
+    .sort()
+    .filter((key) => object[key] !== undefined)
+    .map((key) => `${JSON.stringify(key)}:${stableStringify(object[key])}`);
+  return `{${pairs.join(",")}}`;
+}
+
+export function featureGeometryKey(f: Pick<FeatureIdentityInput, "sourceLayer" | "geometry">): string {
+  return `${f.sourceLayer}::${JSON.stringify(f.geometry)}`;
+}
+
+export function featurePropertiesKey(f: Pick<FeatureIdentityInput, "sourceLayer" | "properties">): string {
+  return `${f.sourceLayer}::${stableStringify(f.properties)}`;
+}
+
+export function sourceTileZoomCandidates(
+  mapZoom: number,
+  minZoom = GSI_SOURCE_MIN_ZOOM,
+  maxZoom = GSI_SOURCE_MAX_ZOOM,
+): number[] {
+  if (!Number.isFinite(mapZoom)) return [maxZoom];
+  const out: number[] = [];
+  for (const z of [Math.floor(mapZoom), Math.ceil(mapZoom)]) {
+    const clamped = Math.max(minZoom, Math.min(maxZoom, z));
+    if (!out.includes(clamped)) out.push(clamped);
+  }
+  return out;
+}
+
+function distanceToNearestInteger(v: number): number {
+  return Math.abs(v - Math.round(v));
+}
+
+function tileX(lng: number, zoom: number): number {
+  return ((lng + 180) / 360) * 2 ** zoom;
+}
+
+function tileY(lat: number, zoom: number): number {
+  const rad = (lat * Math.PI) / 180;
+  return ((1 - Math.log(Math.tan(rad) + 1 / Math.cos(rad)) / Math.PI) / 2) * 2 ** zoom;
+}
+
+function isNearTileBoundary(
+  p: Position,
+  sourceZooms: ReadonlyArray<number>,
+  epsilon = TILE_BOUNDARY_EPSILON,
+): boolean {
+  const lng = p[0];
+  const lat = p[1];
+  if (typeof lng !== "number" || typeof lat !== "number") return false;
+  if (!Number.isFinite(lng) || !Number.isFinite(lat)) return false;
+
+  for (const z of sourceZooms) {
+    const x = tileX(lng, z);
+    const y = tileY(lat, z);
+    if (distanceToNearestInteger(x) <= epsilon) return true;
+    if (distanceToNearestInteger(y) <= epsilon) return true;
+  }
+  return false;
+}
+
+function extendBounds(bounds: ScreenBounds | null, p: ScreenPoint): ScreenBounds {
+  if (!bounds) return { minX: p.x, minY: p.y, maxX: p.x, maxY: p.y };
+  return {
+    minX: Math.min(bounds.minX, p.x),
+    minY: Math.min(bounds.minY, p.y),
+    maxX: Math.max(bounds.maxX, p.x),
+    maxY: Math.max(bounds.maxY, p.y),
+  };
+}
+
+function projectPosition(
+  p: Position,
+  project: ProjectFn,
+  sourceZooms: ReadonlyArray<number>,
+): ProjectedPoint | null {
+  const lng = p[0];
+  const lat = p[1];
+  if (typeof lng !== "number" || typeof lat !== "number") return null;
+  if (!Number.isFinite(lng) || !Number.isFinite(lat)) return null;
+  const screen = project(lng, lat);
+  if (!Number.isFinite(screen.x) || !Number.isFinite(screen.y)) return null;
+  return {
+    x: screen.x,
+    y: screen.y,
+    nearTileBoundary: isNearTileBoundary(p, sourceZooms),
+  };
+}
+
+function addPath(
+  coords: Position[],
+  project: ProjectFn,
+  sourceZooms: ReadonlyArray<number>,
+  paths: ProjectedPath[],
+  currentBounds: ScreenBounds | null,
+): { bounds: ScreenBounds | null; hasTileBoundaryPoint: boolean } {
+  const points: ProjectedPoint[] = [];
+  let bounds = currentBounds;
+  let hasTileBoundaryPoint = false;
+
+  for (const c of coords) {
+    const p = projectPosition(c, project, sourceZooms);
+    if (!p) continue;
+    points.push(p);
+    bounds = extendBounds(bounds, p);
+    hasTileBoundaryPoint ||= p.nearTileBoundary;
+  }
+
+  if (points.length > 0) paths.push({ points });
+  return { bounds, hasTileBoundaryPoint };
+}
+
+function projectGeometry(
+  geometry: Geometry,
+  project: ProjectFn,
+  sourceZooms: ReadonlyArray<number>,
+): ProjectedGeometry {
+  const paths: ProjectedPath[] = [];
+  let bounds: ScreenBounds | null = null;
+  let hasTileBoundaryPoint = false;
+
+  const merge = (result: { bounds: ScreenBounds | null; hasTileBoundaryPoint: boolean }) => {
+    bounds = result.bounds;
+    hasTileBoundaryPoint ||= result.hasTileBoundaryPoint;
+  };
+
+  const visit = (g: Geometry): void => {
+    switch (g.type) {
+      case "Point":
+        merge(addPath([g.coordinates], project, sourceZooms, paths, bounds));
+        break;
+      case "MultiPoint":
+      case "LineString":
+        merge(addPath(g.coordinates, project, sourceZooms, paths, bounds));
+        break;
+      case "MultiLineString":
+      case "Polygon":
+        for (const line of g.coordinates) {
+          merge(addPath(line, project, sourceZooms, paths, bounds));
+        }
+        break;
+      case "MultiPolygon":
+        for (const polygon of g.coordinates) {
+          for (const ring of polygon) {
+            merge(addPath(ring, project, sourceZooms, paths, bounds));
+          }
+        }
+        break;
+      case "GeometryCollection":
+        for (const child of g.geometries) visit(child);
+        break;
+      default:
+        break;
+    }
+  };
+
+  visit(geometry);
+  return { bounds, hasTileBoundaryPoint, paths };
+}
+
+function screenBoundsDistance(a: ScreenBounds, b: ScreenBounds): number {
+  const dx = Math.max(0, a.minX - b.maxX, b.minX - a.maxX);
+  const dy = Math.max(0, a.minY - b.maxY, b.minY - a.maxY);
+  return Math.hypot(dx, dy);
+}
+
+function dist(a: ScreenPoint, b: ScreenPoint): number {
+  return Math.hypot(a.x - b.x, a.y - b.y);
+}
+
+function cross(a: ScreenPoint, b: ScreenPoint, c: ScreenPoint): number {
+  return (b.x - a.x) * (c.y - a.y) - (b.y - a.y) * (c.x - a.x);
+}
+
+function isOnSegment(a: ScreenPoint, b: ScreenPoint, p: ScreenPoint): boolean {
+  const eps = 1e-9;
+  return (
+    Math.abs(cross(a, b, p)) <= eps &&
+    p.x >= Math.min(a.x, b.x) - eps &&
+    p.x <= Math.max(a.x, b.x) + eps &&
+    p.y >= Math.min(a.y, b.y) - eps &&
+    p.y <= Math.max(a.y, b.y) + eps
+  );
+}
+
+function segmentsIntersect(
+  a1: ScreenPoint,
+  a2: ScreenPoint,
+  b1: ScreenPoint,
+  b2: ScreenPoint,
+): boolean {
+  const d1 = cross(a1, a2, b1);
+  const d2 = cross(a1, a2, b2);
+  const d3 = cross(b1, b2, a1);
+  const d4 = cross(b1, b2, a2);
+
+  if (d1 === 0 && isOnSegment(a1, a2, b1)) return true;
+  if (d2 === 0 && isOnSegment(a1, a2, b2)) return true;
+  if (d3 === 0 && isOnSegment(b1, b2, a1)) return true;
+  if (d4 === 0 && isOnSegment(b1, b2, a2)) return true;
+  return (d1 > 0) !== (d2 > 0) && (d3 > 0) !== (d4 > 0);
+}
+
+function segmentDistance(
+  a1: ScreenPoint,
+  a2: ScreenPoint,
+  b1: ScreenPoint,
+  b2: ScreenPoint,
+): number {
+  if (segmentsIntersect(a1, a2, b1, b2)) return 0;
+  return Math.min(
+    pointToSegmentDistance(a1, b1, b2),
+    pointToSegmentDistance(a2, b1, b2),
+    pointToSegmentDistance(b1, a1, a2),
+    pointToSegmentDistance(b2, a1, a2),
+  );
+}
+
+function hasNearTileBoundaryContact(
+  a: ProjectedGeometry,
+  b: ProjectedGeometry,
+  marginPx: number,
+): boolean {
+  if (!a.hasTileBoundaryPoint || !b.hasTileBoundaryPoint) return false;
+
+  for (const ap of a.paths) {
+    for (const bp of b.paths) {
+      for (const p of ap.points) {
+        if (!p.nearTileBoundary) continue;
+        for (const q of bp.points) {
+          if (q.nearTileBoundary && dist(p, q) <= marginPx) return true;
+        }
+      }
+
+      for (let i = 0; i < ap.points.length - 1; i++) {
+        const a1 = ap.points[i]!;
+        const a2 = ap.points[i + 1]!;
+        const aSegmentOnBoundary = a1.nearTileBoundary && a2.nearTileBoundary;
+
+        for (let j = 0; j < bp.points.length - 1; j++) {
+          const b1 = bp.points[j]!;
+          const b2 = bp.points[j + 1]!;
+          const bSegmentOnBoundary = b1.nearTileBoundary && b2.nearTileBoundary;
+
+          if (
+            aSegmentOnBoundary &&
+            bSegmentOnBoundary &&
+            segmentDistance(a1, a2, b1, b2) <= marginPx
+          ) {
+            return true;
+          }
+
+          if (
+            aSegmentOnBoundary &&
+            ((b1.nearTileBoundary && pointToSegmentDistance(b1, a1, a2) <= marginPx) ||
+              (b2.nearTileBoundary && pointToSegmentDistance(b2, a1, a2) <= marginPx))
+          ) {
+            return true;
+          }
+
+          if (
+            bSegmentOnBoundary &&
+            ((a1.nearTileBoundary && pointToSegmentDistance(a1, b1, b2) <= marginPx) ||
+              (a2.nearTileBoundary && pointToSegmentDistance(a2, b1, b2) <= marginPx))
+          ) {
+            return true;
+          }
+        }
+      }
+    }
+  }
+
+  return false;
+}
+
+function areProjectedTileSplitParts(
+  a: ProjectedGeometry,
+  b: ProjectedGeometry,
+  marginPx: number,
+): boolean {
+  if (!a.bounds || !b.bounds) return false;
+  if (screenBoundsDistance(a.bounds, b.bounds) > marginPx) return false;
+  return hasNearTileBoundaryContact(a, b, marginPx);
+}
+
+function buildDescriptor(
+  feature: FeatureIdentityInput,
+  project: ProjectFn,
+  sourceZooms: ReadonlyArray<number>,
+): FeatureDescriptor {
+  return {
+    key: featureGeometryKey(feature),
+    propsKey: featurePropertiesKey(feature),
+    projected: projectGeometry(feature.geometry, project, sourceZooms),
+  };
+}
+
+export function areLikelyTileSplitParts(
+  a: FeatureIdentityInput,
+  b: FeatureIdentityInput,
+  project: ProjectFn,
+  sourceZooms: ReadonlyArray<number>,
+  marginPx = PARTIAL_PROTECTION_MARGIN_PX,
+): boolean {
+  if (a.sourceLayer !== b.sourceLayer) return false;
+  if (featurePropertiesKey(a) !== featurePropertiesKey(b)) return false;
+  const ad = buildDescriptor(a, project, sourceZooms);
+  const bd = buildDescriptor(b, project, sourceZooms);
+  return areProjectedTileSplitParts(ad.projected, bd.projected, marginPx);
+}
+
+export function protectedFeatureKeysForInverseDelete({
+  selected,
+  candidates,
+  project,
+  sourceZooms,
+  marginPx = PARTIAL_PROTECTION_MARGIN_PX,
+}: {
+  selected: ReadonlyArray<FeatureIdentityInput>;
+  candidates: ReadonlyArray<FeatureIdentityInput>;
+  project: ProjectFn;
+  sourceZooms: ReadonlyArray<number>;
+  marginPx?: number;
+}): Set<string> {
+  const protectedKeys = new Set<string>();
+  const protectedByProps = new Map<string, FeatureDescriptor[]>();
+
+  const addProtected = (descriptor: FeatureDescriptor): void => {
+    if (protectedKeys.has(descriptor.key)) return;
+    protectedKeys.add(descriptor.key);
+    const list = protectedByProps.get(descriptor.propsKey);
+    if (list) list.push(descriptor);
+    else protectedByProps.set(descriptor.propsKey, [descriptor]);
+  };
+
+  for (const f of selected) {
+    addProtected(buildDescriptor(f, project, sourceZooms));
+  }
+
+  const candidateDescriptors = candidates.map((f) => buildDescriptor(f, project, sourceZooms));
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (const candidate of candidateDescriptors) {
+      if (protectedKeys.has(candidate.key)) continue;
+      const protectedGroup = protectedByProps.get(candidate.propsKey);
+      if (!protectedGroup) continue;
+      if (
+        protectedGroup.some((protectedFeature) =>
+          areProjectedTileSplitParts(candidate.projected, protectedFeature.projected, marginPx),
+        )
+      ) {
+        addProtected(candidate);
+        changed = true;
+      }
+    }
+  }
+
+  return protectedKeys;
+}

--- a/src/map/hiddenSync.ts
+++ b/src/map/hiddenSync.ts
@@ -7,8 +7,9 @@ import { HIDEABLE_LAYER_IDS } from "./style";
  * 非表示にしたい feature（`editState.hidden`）と MapLibre の feature-state を同期する。
  *
  * GSI ベクトルタイルは元から feature.id を持たず、本アプリでは `addProtocol('gsi-ids')`
- * がタイル内で連番 id を注入する。しかし同じ「論理 feature」でも **タイルを跨ぐと別の id**
- * になるため、`setFeatureState({id})` を単発で呼ぶだけでは広域にパンされた時に反映されない。
+ * がタイル座標 + タイル内連番由来の id を注入する。id は sourceLayer 内でタイルを
+ * 跨いでも衝突しないが、同じ「論理 feature」でもタイルを跨ぐと別 id になるため、
+ * `setFeatureState({id})` を単発で呼ぶだけでは広域にパンされた時に反映されない。
  *
  * そこで editState 側は sourceLayer + geometry で識別を保持し、以下のタイミングで
  * 「現在 rendered な feature を走査 → geometry がマッチした feature に feature-state を付ける」

--- a/src/map/idProtocol.ts
+++ b/src/map/idProtocol.ts
@@ -12,16 +12,30 @@ import vtpbf from "vt-pbf";
  *
  * ここでは `gsi-ids://...` という独自プロトコルを MapLibre に登録し、
  * 実 URL から取得した pbf を一旦 @mapbox/vector-tile でパース → 各 layer の
- * 各 feature に「そのタイル内でユニークな連番 id」を注入 → vt-pbf で
+ * 各 feature に「タイル座標 + タイル内連番」由来の id を注入 → vt-pbf で
  * 再エンコード、という流れで id 付き pbf を返す。
  *
- * id はタイルをまたいで同一 feature に同じ値になるわけではない点に注意
+ * id は sourceLayer 内でタイルをまたいでも衝突しないが、同じ論理 feature に
+ * 同じ値になるわけではない点に注意
  * （GSI のベクトルタイルは元から跨ぎ feature にグローバル id を持たない）。
  * タイル跨ぎの同一性は geometry 比較で扱う（`editState` 側の責務）。
  */
 
 const PROTOCOL_NAME = "gsi-ids";
 const PROTOCOL_PREFIX = `${PROTOCOL_NAME}://`;
+const TILE_COORD_BITS = 16;
+const FEATURE_INDEX_BITS = 16;
+const TILE_COORD_BASE = 2 ** TILE_COORD_BITS;
+const FEATURE_INDEX_BASE = 2 ** FEATURE_INDEX_BITS;
+const MAX_PACKED_SOURCE_ZOOM = 16;
+const MAX_TILE_COORD = TILE_COORD_BASE - 1;
+const MAX_FEATURE_INDEX = FEATURE_INDEX_BASE - 1;
+
+export interface TileCoord {
+  z: number;
+  x: number;
+  y: number;
+}
 
 /** `gsi-ids://host/path` → `https://host/path` に書き戻す。 */
 export function toRealUrl(protocolUrl: string): string {
@@ -40,6 +54,47 @@ export function toProtocolUrl(realUrl: string): string {
   return realUrl;
 }
 
+export function tileCoordFromUrl(url: string): TileCoord | null {
+  const m = /\/(\d+)\/(\d+)\/(\d+)\.pbf(?:[?#].*)?$/.exec(url);
+  if (!m) return null;
+  const z = Number(m[1]);
+  const x = Number(m[2]);
+  const y = Number(m[3]);
+  if (!Number.isInteger(z) || !Number.isInteger(x) || !Number.isInteger(y)) return null;
+  return { z, x, y };
+}
+
+export function tileFeatureId(tile: TileCoord, featureIndex: number): number {
+  if (
+    !Number.isInteger(tile.z) ||
+    !Number.isInteger(tile.x) ||
+    !Number.isInteger(tile.y) ||
+    !Number.isInteger(featureIndex)
+  ) {
+    throw new Error("tile feature id requires integer z/x/y/featureIndex");
+  }
+  if (tile.z < 0 || tile.z > MAX_PACKED_SOURCE_ZOOM) {
+    throw new Error(`tile z out of packed id range: ${tile.z}`);
+  }
+  if (tile.x < 0 || tile.x > MAX_TILE_COORD || tile.y < 0 || tile.y > MAX_TILE_COORD) {
+    throw new Error(`tile coord out of packed id range: ${tile.z}/${tile.x}/${tile.y}`);
+  }
+  if (featureIndex < 0 || featureIndex > MAX_FEATURE_INDEX - 1) {
+    throw new Error(`feature index out of packed id range: ${featureIndex}`);
+  }
+
+  const featureOrdinal = featureIndex + 1; // 0 を避ける。
+  const id =
+    tile.z * TILE_COORD_BASE * TILE_COORD_BASE * FEATURE_INDEX_BASE +
+    tile.x * TILE_COORD_BASE * FEATURE_INDEX_BASE +
+    tile.y * FEATURE_INDEX_BASE +
+    featureOrdinal;
+  if (!Number.isSafeInteger(id)) {
+    throw new Error(`packed tile feature id is not a safe integer: ${id}`);
+  }
+  return id;
+}
+
 /**
  * @mapbox/vector-tile の VectorTileLayer を vt-pbf の writeLayer 用にラップし、
  * feature() が返す VectorTileFeature に id を注入する。
@@ -53,7 +108,10 @@ class IdInjectingLayer {
   version: number;
   extent: number;
 
-  constructor(private original: VectorTileLayer) {
+  constructor(
+    private original: VectorTileLayer,
+    private tile: TileCoord,
+  ) {
     this.length = original.length;
     this.name = original.name;
     this.version = original.version;
@@ -63,9 +121,9 @@ class IdInjectingLayer {
   feature(i: number) {
     const f = this.original.feature(i);
     // VectorTileFeature.id は number | undefined。
-    // 0 を避けて 1-origin で割り当てる（MapLibre の feature-state は 0 も扱えるが、
-    // falsy 判定の事故を避ける意味でも 1-origin が安全）。
-    f.id = i + 1;
+    // MapLibre の feature-state は {source, sourceLayer, id} で管理され、tile 座標を
+    // キーに含めないため、タイル内連番だけだと別タイルの feature に飛び火する。
+    f.id = tileFeatureId(this.tile, i);
     return f;
   }
 }
@@ -74,13 +132,16 @@ class IdInjectingLayer {
  * pbf ArrayBuffer に id を注入して返す。
  * サイズ 0（空タイル応答）や pbf 解析失敗時は入力をそのまま返す。
  */
-export function injectIdsIntoTilePbf(buf: ArrayBuffer): ArrayBuffer {
+export function injectIdsIntoTilePbf(
+  buf: ArrayBuffer,
+  tile: TileCoord = { z: 0, x: 0, y: 0 },
+): ArrayBuffer {
   if (buf.byteLength === 0) return buf;
-  const tile = new VectorTile(new Pbf(buf));
+  const vectorTile = new VectorTile(new Pbf(buf));
   const wrappedLayers: Record<string, IdInjectingLayer> = {};
-  for (const name of Object.keys(tile.layers)) {
-    const layer = tile.layers[name];
-    if (layer) wrappedLayers[name] = new IdInjectingLayer(layer);
+  for (const name of Object.keys(vectorTile.layers)) {
+    const layer = vectorTile.layers[name];
+    if (layer) wrappedLayers[name] = new IdInjectingLayer(layer, tile);
   }
   const out = vtpbf({ layers: wrappedLayers }) as Uint8Array;
   // Uint8Array.buffer が大きすぎる（Pbf の内部バッファが余剰を持つ）ケースに備え、
@@ -100,6 +161,8 @@ export function registerGsiIdsProtocol(
 ): void {
   ml.addProtocol(PROTOCOL_NAME, async (params, abortController) => {
     const realUrl = toRealUrl(params.url);
+    const tile = tileCoordFromUrl(realUrl);
+    if (!tile) throw new Error(`could not parse tile z/x/y from URL: ${realUrl}`);
     const res = await fetchImpl(realUrl, { signal: abortController.signal });
     if (!res.ok) {
       // 404 はそのタイルが存在しないだけなので空応答で扱う（MapLibre 側が無視する）。
@@ -107,7 +170,7 @@ export function registerGsiIdsProtocol(
       throw new Error(`tile fetch failed: ${res.status} ${realUrl}`);
     }
     const buf = await res.arrayBuffer();
-    const out = injectIdsIntoTilePbf(buf);
+    const out = injectIdsIntoTilePbf(buf, tile);
     return { data: out };
   });
 }

--- a/src/map/zoomLock.ts
+++ b/src/map/zoomLock.ts
@@ -1,0 +1,42 @@
+import type { Map as MapLibreMap } from "maplibre-gl";
+
+/**
+ * 編集中のズーム変更を抑止するためのロック制御。#35
+ *
+ * GSI ベクトルタイルにはグローバル feature ID が無く、内部では
+ * `(sourceLayer + geometry deep-equal)` で同一性判定している。ズームを跨ぐと
+ * 同じ論理 feature でも geometry が simplify されて別物になり、
+ * editState.hidden の登録とまったくマッチしなくなるため、編集中はズーム固定が安全。
+ *
+ * setMinZoom / setMaxZoom を現在ズームに揃えることで、scroll / dblclick / pinch /
+ * NavigationControl の +/- など全経路を抑制する（MapLibre の仕様）。
+ */
+
+export interface ZoomLockSnapshot {
+  minZoom: number;
+  maxZoom: number;
+}
+
+/** ロック前の min/max を返し、現行ズームに固定する。 */
+export function lockZoom(map: MapLibreMap): ZoomLockSnapshot {
+  const before: ZoomLockSnapshot = {
+    minZoom: map.getMinZoom(),
+    maxZoom: map.getMaxZoom(),
+  };
+  const z = map.getZoom();
+  map.setMinZoom(z);
+  map.setMaxZoom(z);
+  return before;
+}
+
+/** snapshot の値で min/max を戻す。 */
+export function unlockZoom(map: MapLibreMap, prev: ZoomLockSnapshot): void {
+  map.setMinZoom(prev.minZoom);
+  map.setMaxZoom(prev.maxZoom);
+}
+
+/** UI 表示用：ズームを少数 2 桁で `Z 15.32` 形式に整形。 */
+export function formatZoomDisplay(zoom: number, locked: boolean): string {
+  const z = zoom.toFixed(2);
+  return locked ? `Z ${z} 🔒` : `Z ${z}`;
+}

--- a/tests/e2e/display-and-export.spec.ts
+++ b/tests/e2e/display-and-export.spec.ts
@@ -920,6 +920,99 @@ test("select multiple → 「選択以外を削除」 hides surrounding features
   expect(hiddenAfterUndo).toBe(hiddenBefore);
 });
 
+test("編集中はズームロック、リセットでロック解除、表示はリアルタイム更新", async ({ page }) => {
+  await page.goto("/");
+  await page.waitForFunction(() => document.body.dataset.mapReady === "true", null, {
+    timeout: 30_000,
+  });
+  await page.evaluate(() => {
+    const g = window as unknown as { __mlMap?: { setZoom(z: number): void } };
+    g.__mlMap?.setZoom(15);
+  });
+  await page.waitForFunction(
+    () => {
+      const g = window as unknown as {
+        __mlMap?: { getZoom(): number; isStyleLoaded(): boolean; areTilesLoaded(): boolean };
+      };
+      return (
+        !!g.__mlMap &&
+        Math.round(g.__mlMap.getZoom()) === 15 &&
+        g.__mlMap.isStyleLoaded() &&
+        g.__mlMap.areTilesLoaded()
+      );
+    },
+    null,
+    { timeout: 15_000 },
+  );
+
+  // ロック前：min/max は MapLibre のデフォルト範囲のはず
+  const beforeLock = await page.evaluate(() => {
+    const g = window as unknown as {
+      __mlMap?: { getMinZoom(): number; getMaxZoom(): number; getZoom(): number };
+    };
+    return {
+      min: g.__mlMap!.getMinZoom(),
+      max: g.__mlMap!.getMaxZoom(),
+      zoom: g.__mlMap!.getZoom(),
+    };
+  });
+  expect(beforeLock.min).toBeLessThan(beforeLock.zoom);
+  expect(beforeLock.max).toBeGreaterThan(beforeLock.zoom);
+  await expect(page.locator("#zoom-display")).toHaveAttribute("data-locked", "false");
+
+  // 中央クリックで feature 選択 → 削除でロック発動
+  await page.evaluate(() => {
+    const canvas = document.querySelector(".maplibregl-canvas") as HTMLElement;
+    const rect = canvas.getBoundingClientRect();
+    const cx = canvas.clientWidth / 2;
+    const cy = canvas.clientHeight / 2;
+    const opts = {
+      bubbles: true,
+      cancelable: true,
+      view: window,
+      clientX: rect.left + cx,
+      clientY: rect.top + cy,
+      button: 0,
+    };
+    canvas.dispatchEvent(new MouseEvent("mousedown", opts));
+    canvas.dispatchEvent(new MouseEvent("mouseup", opts));
+    canvas.dispatchEvent(new MouseEvent("click", opts));
+  });
+  await page.waitForFunction(() => {
+    const g = window as unknown as { __selectionStore?: { state: unknown[] } };
+    return (g.__selectionStore?.state.length ?? 0) > 0;
+  });
+  await page.locator("#delete").click();
+
+  // ロック発動：min == max == 直前のズーム
+  const afterLock = await page.evaluate(() => {
+    const g = window as unknown as {
+      __mlMap?: { getMinZoom(): number; getMaxZoom(): number; getZoom(): number };
+    };
+    return {
+      min: g.__mlMap!.getMinZoom(),
+      max: g.__mlMap!.getMaxZoom(),
+      zoom: g.__mlMap!.getZoom(),
+    };
+  });
+  expect(afterLock.min).toBeCloseTo(afterLock.zoom, 5);
+  expect(afterLock.max).toBeCloseTo(afterLock.zoom, 5);
+  await expect(page.locator("#zoom-display")).toHaveAttribute("data-locked", "true");
+  await expect(page.locator("#zoom-display")).toContainText("🔒");
+
+  // 編集をリセット → ロック解除
+  await page.locator("#reset-edits").click();
+  const afterReset = await page.evaluate(() => {
+    const g = window as unknown as {
+      __mlMap?: { getMinZoom(): number; getMaxZoom(): number };
+    };
+    return { min: g.__mlMap!.getMinZoom(), max: g.__mlMap!.getMaxZoom() };
+  });
+  expect(afterReset.min).toBeCloseTo(beforeLock.min, 5);
+  expect(afterReset.max).toBeCloseTo(beforeLock.max, 5);
+  await expect(page.locator("#zoom-display")).toHaveAttribute("data-locked", "false");
+});
+
 test("layer popover combines visibility and per-layer line width controls", async ({ page }) => {
   await page.goto("/");
   await page.waitForFunction(() => document.body.dataset.mapReady === "true", null, {

--- a/tests/e2e/display-and-export.spec.ts
+++ b/tests/e2e/display-and-export.spec.ts
@@ -920,6 +920,219 @@ test("select multiple → 「選択以外を削除」 hides surrounding features
   expect(hiddenAfterUndo).toBe(hiddenBefore);
 });
 
+test("「選択以外を削除」後に selection を解除して pan しても feature-state が飛び火しない", async ({ page }) => {
+  await page.goto("/");
+  await page.waitForFunction(() => document.body.dataset.mapReady === "true", null, {
+    timeout: 30_000,
+  });
+
+  await page.evaluate(async () => {
+    const g = window as unknown as {
+      __mlMap?: {
+        setBearing(v: number): void;
+        setPitch(v: number): void;
+        setCenter(v: [number, number]): void;
+        setZoom(v: number): void;
+        once(type: "idle", listener: () => void): void;
+      };
+    };
+    const map = g.__mlMap!;
+    map.setBearing(0);
+    map.setPitch(0);
+    map.setCenter([141.35299, 43.06619]);
+    map.setZoom(17);
+    await new Promise<void>((resolve) => map.once("idle", resolve));
+  });
+
+  await page.waitForFunction(
+    () => {
+      const g = window as unknown as {
+        __mlMap?: { getZoom(): number; isStyleLoaded(): boolean; areTilesLoaded(): boolean };
+      };
+      return (
+        !!g.__mlMap &&
+        Math.round(g.__mlMap.getZoom()) === 17 &&
+        g.__mlMap.isStyleLoaded() &&
+        g.__mlMap.areTilesLoaded()
+      );
+    },
+    null,
+    { timeout: 15_000 },
+  );
+
+  const selected = await page.evaluate(() => {
+    const canvas = document.querySelector(".maplibregl-canvas") as HTMLElement;
+    const rect = canvas.getBoundingClientRect();
+    const cx = canvas.clientWidth / 2;
+    const cy = canvas.clientHeight / 2;
+    const size = 240;
+    const p1 = { x: cx - size / 2, y: cy - size / 2 };
+    const p2 = { x: cx + size / 2, y: cy + size / 2 };
+    function mk(type: string, x: number, y: number): MouseEvent {
+      return new MouseEvent(type, {
+        bubbles: true,
+        cancelable: true,
+        view: window,
+        clientX: rect.left + x,
+        clientY: rect.top + y,
+        button: 0,
+        shiftKey: true,
+      });
+    }
+    canvas.dispatchEvent(mk("mousedown", p1.x, p1.y));
+    canvas.dispatchEvent(mk("mousemove", (p1.x + p2.x) / 2, (p1.y + p2.y) / 2));
+    canvas.dispatchEvent(mk("mousemove", p2.x, p2.y));
+    canvas.dispatchEvent(mk("mouseup", p2.x, p2.y));
+    const g = window as unknown as { __selectionStore?: { state: unknown[] } };
+    return g.__selectionStore?.state.length ?? 0;
+  });
+  expect(selected).toBeGreaterThan(1);
+
+  await page.locator("#delete-inverse").click();
+
+  async function measureLeaks(): Promise<{
+    hiddenTotal: number;
+    idCollisionGroups: number;
+    notHiddenButStateTrue: number;
+    selectedButStateTrue: number;
+  }> {
+    return await page.evaluate(() => {
+      const g = window as unknown as {
+        __mlMap?: {
+          queryRenderedFeatures(
+            geometry?: unknown,
+            options?: { layers: string[] },
+          ): Array<{
+            id?: string | number;
+            sourceLayer?: string;
+            geometry: unknown;
+          }>;
+          getFeatureState(target: {
+            source: string;
+            sourceLayer: string;
+            id: string | number;
+          }): Record<string, unknown>;
+        };
+        __editState?: { state: { hidden: Array<{ sourceLayer: string; geometry: unknown }> } };
+        __selectionStore?: { state: Array<{ sourceLayer: string; geometry: unknown }> };
+      };
+      const map = g.__mlMap!;
+      const layers = [
+        "waterarea-fill",
+        "waterarea-outline-line",
+        "waterline-line",
+        "river-line",
+        "railway-line",
+        "rail-track-line",
+        "road-line",
+        "road-edge-line",
+        "road-component-line",
+        "building-fill",
+        "building-outline-line",
+        "structure-fill",
+        "structure-outline-line",
+        "boundary-line",
+        "adminarea-boundary-line",
+      ];
+      const keyOf = (sourceLayer: string, geometry: unknown) =>
+        `${sourceLayer}::${JSON.stringify(geometry)}`;
+      const hiddenKeys = new Set(
+        (g.__editState?.state.hidden ?? []).map((h) => keyOf(h.sourceLayer, h.geometry)),
+      );
+      const selectedKeys = new Set(
+        (g.__selectionStore?.state ?? []).map((s) => keyOf(s.sourceLayer, s.geometry)),
+      );
+
+      const raw = map.queryRenderedFeatures(undefined, { layers });
+      const byKey = new Map<string, (typeof raw)[number]>();
+      for (const f of raw) {
+        const sourceLayer = f.sourceLayer ?? "";
+        const key = keyOf(sourceLayer, f.geometry);
+        if (!byKey.has(key)) byKey.set(key, f);
+      }
+
+      const idGroups = new Map<string, string[]>();
+      let notHiddenButStateTrue = 0;
+      let selectedButStateTrue = 0;
+      for (const f of byKey.values()) {
+        const sourceLayer = f.sourceLayer ?? "";
+        const key = keyOf(sourceLayer, f.geometry);
+        const id = f.id;
+        if (id === undefined || id === null) continue;
+        const idKey = `${sourceLayer}::${String(id)}`;
+        const list = idGroups.get(idKey) ?? [];
+        list.push(key);
+        idGroups.set(idKey, list);
+
+        const state = map.getFeatureState({ source: "gsi", sourceLayer, id });
+        const stateHidden = state["hidden"] === true;
+        if (!hiddenKeys.has(key) && stateHidden) notHiddenButStateTrue += 1;
+        if (selectedKeys.has(key) && stateHidden) selectedButStateTrue += 1;
+      }
+
+      let idCollisionGroups = 0;
+      for (const list of idGroups.values()) {
+        if (list.length > 1) idCollisionGroups += 1;
+      }
+      return {
+        hiddenTotal: g.__editState?.state.hidden.length ?? 0,
+        idCollisionGroups,
+        notHiddenButStateTrue,
+        selectedButStateTrue,
+      };
+    });
+  }
+
+  await expect.poll(() => measureLeaks()).toMatchObject({
+    idCollisionGroups: 0,
+    notHiddenButStateTrue: 0,
+    selectedButStateTrue: 0,
+  });
+  expect((await measureLeaks()).hiddenTotal).toBeGreaterThan(0);
+
+  await page.evaluate(() => {
+    const canvas = document.querySelector(".maplibregl-canvas") as HTMLElement;
+    const rect = canvas.getBoundingClientRect();
+    const opts = {
+      bubbles: true,
+      cancelable: true,
+      view: window,
+      clientX: rect.left + 800,
+      clientY: rect.top + 30,
+      button: 0,
+    };
+    canvas.dispatchEvent(new MouseEvent("mousedown", opts));
+    canvas.dispatchEvent(new MouseEvent("mouseup", opts));
+    canvas.dispatchEvent(new MouseEvent("click", opts));
+  });
+
+  await expect.poll(() => measureLeaks()).toMatchObject({
+    idCollisionGroups: 0,
+    notHiddenButStateTrue: 0,
+    selectedButStateTrue: 0,
+  });
+
+  for (const deltaX of [260, -260]) {
+    await page.evaluate(async (dx) => {
+      const g = window as unknown as {
+        __mlMap?: {
+          panBy(offset: [number, number], options: { duration: number }): void;
+          once(type: "idle", listener: () => void): void;
+        };
+      };
+      const map = g.__mlMap!;
+      map.panBy([dx, 0], { duration: 0 });
+      await new Promise<void>((resolve) => map.once("idle", resolve));
+    }, deltaX);
+
+    await expect.poll(() => measureLeaks()).toMatchObject({
+      idCollisionGroups: 0,
+      notHiddenButStateTrue: 0,
+      selectedButStateTrue: 0,
+    });
+  }
+});
+
 test("編集中はズームロック、リセットでロック解除、表示はリアルタイム更新", async ({ page }) => {
   await page.goto("/");
   await page.waitForFunction(() => document.body.dataset.mapReady === "true", null, {

--- a/tests/unit/featureBounds.test.ts
+++ b/tests/unit/featureBounds.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from "vitest";
 import type { Geometry } from "geojson";
 import {
+  centerOfBounds,
   expandBoundsByFactor,
   geometryBounds,
+  pointInBounds,
   unionBounds,
   type LngLatBounds,
 } from "../../src/map/featureBounds";
@@ -93,5 +95,22 @@ describe("expandBoundsByFactor", () => {
   it("退化 BBox（点）は factor によらず点のまま", () => {
     const b: LngLatBounds = [5, 5, 5, 5];
     expect(expandBoundsByFactor(b, 4)).toEqual([5, 5, 5, 5]);
+  });
+});
+
+describe("centerOfBounds / pointInBounds", () => {
+  it("centerOfBounds は両軸の中点", () => {
+    expect(centerOfBounds([0, 0, 10, 20])).toEqual([5, 10]);
+    expect(centerOfBounds([-4, 6, 6, 10])).toEqual([1, 8]);
+  });
+
+  it("pointInBounds は境界含む内側で true、外側で false", () => {
+    const b: LngLatBounds = [0, 0, 10, 10];
+    expect(pointInBounds([5, 5], b)).toBe(true);
+    expect(pointInBounds([0, 0], b)).toBe(true); // 境界
+    expect(pointInBounds([10, 10], b)).toBe(true); // 境界
+    expect(pointInBounds([-0.001, 5], b)).toBe(false);
+    expect(pointInBounds([5, 10.001], b)).toBe(false);
+    expect(pointInBounds([15, 5], b)).toBe(false);
   });
 });

--- a/tests/unit/featureIdentity.test.ts
+++ b/tests/unit/featureIdentity.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest";
+import type { Geometry } from "geojson";
+import {
+  areLikelyTileSplitParts,
+  featureGeometryKey,
+  protectedFeatureKeysForInverseDelete,
+  sourceTileZoomCandidates,
+  stableStringify,
+  type FeatureIdentityInput,
+} from "../../src/map/featureIdentity";
+
+const project = (lng: number, lat: number) => ({ x: lng * 10, y: lat * -10 });
+
+function polygon(minLng: number, minLat: number, maxLng: number, maxLat: number): Geometry {
+  return {
+    type: "Polygon",
+    coordinates: [
+      [
+        [minLng, minLat],
+        [maxLng, minLat],
+        [maxLng, maxLat],
+        [minLng, maxLat],
+        [minLng, minLat],
+      ],
+    ],
+  };
+}
+
+function feature(
+  sourceLayer: string,
+  geometry: Geometry,
+  properties: Record<string, unknown> = { vt_code: 3111 },
+): FeatureIdentityInput {
+  return { sourceLayer, geometry, properties };
+}
+
+describe("stableStringify", () => {
+  it("object key order に依存しない", () => {
+    expect(stableStringify({ b: 2, a: 1 })).toBe(stableStringify({ a: 1, b: 2 }));
+  });
+
+  it("nested object / array も安定化する", () => {
+    expect(stableStringify({ z: [{ b: 2, a: 1 }] })).toBe(
+      stableStringify({ z: [{ a: 1, b: 2 }] }),
+    );
+  });
+});
+
+describe("sourceTileZoomCandidates", () => {
+  it("現在 zoom の floor/ceil を GSI source zoom 範囲内に丸める", () => {
+    expect(sourceTileZoomCandidates(15.25)).toEqual([15, 16]);
+    expect(sourceTileZoomCandidates(16.8)).toEqual([16]);
+    expect(sourceTileZoomCandidates(3.2)).toEqual([4]);
+  });
+});
+
+describe("areLikelyTileSplitParts", () => {
+  it("同じ属性でタイル境界上に接している geometry を split partial とみなす", () => {
+    const left = feature("BldA", polygon(-1, 0, 0, 1));
+    const right = feature("BldA", polygon(0, 0, 1, 1));
+
+    expect(areLikelyTileSplitParts(left, right, project, [1])).toBe(true);
+  });
+
+  it("同じ属性でも離れた geometry は split partial とみなさない", () => {
+    const selected = feature("BldA", polygon(-1, 0, 0, 1));
+    const far = feature("BldA", polygon(10, 0, 11, 1));
+
+    expect(areLikelyTileSplitParts(selected, far, project, [1])).toBe(false);
+  });
+
+  it("同じ属性で接していてもタイル境界でなければ split partial とみなさない", () => {
+    const selected = feature("BldA", polygon(4, 10, 5, 11));
+    const touchingNeighbor = feature("BldA", polygon(5, 10, 6, 11));
+
+    expect(areLikelyTileSplitParts(selected, touchingNeighbor, project, [1])).toBe(false);
+  });
+
+  it("sourceLayer が違うものは split partial とみなさない", () => {
+    const selected = feature("BldA", polygon(-1, 0, 0, 1));
+    const otherLayer = feature("StrctArea", polygon(0, 0, 1, 1));
+
+    expect(areLikelyTileSplitParts(selected, otherLayer, project, [1])).toBe(false);
+  });
+});
+
+describe("protectedFeatureKeysForInverseDelete", () => {
+  it("選択済み geometry と、タイル境界でつながる同一属性 partial だけを保護する", () => {
+    const selected = feature("BldA", polygon(-1, 0, 0, 1), { vt_code: 3111 });
+    const splitPart = feature("BldA", polygon(0, 0, 1, 1), { vt_code: 3111 });
+    const samePropsFarAway = feature("BldA", polygon(10, 0, 11, 1), { vt_code: 3111 });
+    const differentPropsTouching = feature("BldA", polygon(0, 1, 1, 2), { vt_code: 9999 });
+
+    const protectedKeys = protectedFeatureKeysForInverseDelete({
+      selected: [selected],
+      candidates: [selected, splitPart, samePropsFarAway, differentPropsTouching],
+      project,
+      sourceZooms: [1],
+    });
+
+    expect(protectedKeys.has(featureGeometryKey(selected))).toBe(true);
+    expect(protectedKeys.has(featureGeometryKey(splitPart))).toBe(true);
+    expect(protectedKeys.has(featureGeometryKey(samePropsFarAway))).toBe(false);
+    expect(protectedKeys.has(featureGeometryKey(differentPropsTouching))).toBe(false);
+  });
+
+  it("直接選択部分から連続する split partial を推移的に保護する", () => {
+    const selected = feature("AdmArea", polygon(-45, 0, 0, 1), { vt_code: 1103 });
+    const part2 = feature("AdmArea", polygon(0, 0, 45, 1), { vt_code: 1103 });
+    const part3 = feature("AdmArea", polygon(45, 0, 90, 1), { vt_code: 1103 });
+
+    const protectedKeys = protectedFeatureKeysForInverseDelete({
+      selected: [selected],
+      candidates: [part3, part2],
+      project,
+      sourceZooms: [3],
+    });
+
+    expect(protectedKeys.has(featureGeometryKey(part2))).toBe(true);
+    expect(protectedKeys.has(featureGeometryKey(part3))).toBe(true);
+  });
+});

--- a/tests/unit/idProtocol.test.ts
+++ b/tests/unit/idProtocol.test.ts
@@ -6,6 +6,8 @@ import Pbf from "pbf";
 import vtpbf from "vt-pbf";
 import {
   injectIdsIntoTilePbf,
+  tileCoordFromUrl,
+  tileFeatureId,
   toProtocolUrl,
   toRealUrl,
 } from "../../src/map/idProtocol";
@@ -29,6 +31,31 @@ describe("URL helpers", () => {
 
   it("leaves non gsi-ids URL alone", () => {
     expect(toRealUrl("https://example.com/x.pbf")).toBe("https://example.com/x.pbf");
+  });
+});
+
+describe("tile id helpers", () => {
+  it("parses z/x/y from a GSI tile URL", () => {
+    expect(
+      tileCoordFromUrl("https://cyberjapandata.gsi.go.jp/xyz/optimal_bvmap-v1/16/58500/24064.pbf"),
+    ).toEqual({ z: 16, x: 58500, y: 24064 });
+    expect(
+      tileCoordFromUrl(
+        "gsi-ids://cyberjapandata.gsi.go.jp/xyz/optimal_bvmap-v1/15/29250/12032.pbf?foo=1",
+      ),
+    ).toEqual({ z: 15, x: 29250, y: 12032 });
+  });
+
+  it("packs z/x/y/featureIndex into a safe, non-zero integer id", () => {
+    const id = tileFeatureId({ z: 16, x: 58500, y: 24064 }, 117);
+    expect(id).toBe(4754856791244918);
+    expect(Number.isSafeInteger(id)).toBe(true);
+  });
+
+  it("uses different ids for the same feature index in adjacent tiles", () => {
+    const a = tileFeatureId({ z: 16, x: 58500, y: 24064 }, 0);
+    const b = tileFeatureId({ z: 16, x: 58501, y: 24064 }, 0);
+    expect(a).not.toBe(b);
   });
 });
 
@@ -86,9 +113,10 @@ describe("injectIdsIntoTilePbf", () => {
     expect(out.byteLength).toBe(0);
   });
 
-  it("round-trips a tile and assigns 1-origin feature ids per layer", () => {
+  it("round-trips a tile and assigns tile-scoped feature ids per layer", () => {
     const buf = buildShimTilePbf();
-    const out = injectIdsIntoTilePbf(buf);
+    const tileCoord = { z: 16, x: 58500, y: 24064 };
+    const out = injectIdsIntoTilePbf(buf, tileCoord);
     expect(out.byteLength).toBeGreaterThan(0);
 
     const tile = new VectorTile(new Pbf(out));
@@ -96,12 +124,12 @@ describe("injectIdsIntoTilePbf", () => {
 
     const road = tile.layers["road"]!;
     expect(road.length).toBe(2);
-    expect(road.feature(0).id).toBe(1);
-    expect(road.feature(1).id).toBe(2);
+    expect(road.feature(0).id).toBe(tileFeatureId(tileCoord, 0));
+    expect(road.feature(1).id).toBe(tileFeatureId(tileCoord, 1));
 
     const building = tile.layers["building"]!;
     expect(building.length).toBe(1);
-    expect(building.feature(0).id).toBe(1);
+    expect(building.feature(0).id).toBe(tileFeatureId(tileCoord, 0));
     expect(building.feature(0).properties["name"]).toBe("x");
   });
 

--- a/tests/unit/zoomLock.test.ts
+++ b/tests/unit/zoomLock.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Map as MapLibreMap } from "maplibre-gl";
+import { formatZoomDisplay, lockZoom, unlockZoom } from "../../src/map/zoomLock";
+
+function fakeMap(initial: { zoom: number; minZoom: number; maxZoom: number }) {
+  let zoom = initial.zoom;
+  let minZoom = initial.minZoom;
+  let maxZoom = initial.maxZoom;
+  return {
+    getZoom: vi.fn(() => zoom),
+    getMinZoom: vi.fn(() => minZoom),
+    getMaxZoom: vi.fn(() => maxZoom),
+    setMinZoom: vi.fn((v: number) => {
+      minZoom = v;
+    }),
+    setMaxZoom: vi.fn((v: number) => {
+      maxZoom = v;
+    }),
+    _read: () => ({ zoom, minZoom, maxZoom }),
+  };
+}
+
+describe("lockZoom / unlockZoom", () => {
+  it("ロックは min/max を現在ズームに揃え、unlock で元に戻る", () => {
+    const m = fakeMap({ zoom: 15.5, minZoom: 0, maxZoom: 22 });
+    const snap = lockZoom(m as unknown as MapLibreMap);
+    expect(snap).toEqual({ minZoom: 0, maxZoom: 22 });
+    expect(m._read()).toEqual({ zoom: 15.5, minZoom: 15.5, maxZoom: 15.5 });
+
+    unlockZoom(m as unknown as MapLibreMap, snap);
+    expect(m._read()).toEqual({ zoom: 15.5, minZoom: 0, maxZoom: 22 });
+  });
+
+  it("既に部分的に制限されているケースでも snapshot 通りに戻る", () => {
+    const m = fakeMap({ zoom: 14, minZoom: 10, maxZoom: 18 });
+    const snap = lockZoom(m as unknown as MapLibreMap);
+    expect(m._read()).toEqual({ zoom: 14, minZoom: 14, maxZoom: 14 });
+
+    unlockZoom(m as unknown as MapLibreMap, snap);
+    expect(m._read()).toEqual({ zoom: 14, minZoom: 10, maxZoom: 18 });
+  });
+});
+
+describe("formatZoomDisplay", () => {
+  it("通常表示は Z {小数2桁}", () => {
+    expect(formatZoomDisplay(15, false)).toBe("Z 15.00");
+    expect(formatZoomDisplay(15.327, false)).toBe("Z 15.33");
+  });
+
+  it("ロック中は鍵マーク付き", () => {
+    expect(formatZoomDisplay(15.5, true)).toBe("Z 15.50 🔒");
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,6 +11,9 @@ export default defineConfig({
     __APP_VERSION__: JSON.stringify(pkg.version),
   },
   server: {
+    // Playwright が webServer 起動を 127.0.0.1:5173 で待つため明示。
+    // 既定の localhost は IPv6 (::1) も含み、IPv4 待ち受けと噛み合わない環境がある。
+    host: "127.0.0.1",
     port: 5173,
     strictPort: true,
   },


### PR DESCRIPTION
Closes #35

## Summary

PR #34（「選択以外を削除」）後の動作確認で「残したはずの feature が消える / 出る / 安定しない」という不具合が出ていた件への短期ガードレール実装。根本原因と対処は [#35](https://github.com/inuro/map-simplifier/issues/35) 参照。長期対応はタイル跨ぎ同一性の改修として [#36](https://github.com/inuro/map-simplifier/issues/36) に分離。

## 変更点

### A. 編集中ズームロック
- `src/map/zoomLock.ts`（新規）: `lockZoom` / `unlockZoom` / `formatZoomDisplay` を純関数で実装。`setMinZoom` / `setMaxZoom` を現行ズームに揃え、scroll / dblclick / pinch / NavigationControl +/- すべてを抑止。
- `src/main.ts`: `editState.subscribe` で `hidden` または `highlighted` が非空なら `lockZoom`、空なら `unlockZoom`。スナップショットで元の min/max を復元。

### B. ズームレベル表示 UI
- `index.html`: `#zoom-display` を `spacer` の右に配置。`Z 15.32` / 編集中は `Z 15.32 🔒`。`data-locked` で UI フラグ公開。
- `header` の `flex-wrap` を `wrap` → `nowrap`、`overflow-x: auto` を追加。要素数増加で折り返すと layer-visibility popover が viewport 外に出る問題を回避。

### C. 「選択以外を削除」の partial 除外
- `src/map/featureBounds.ts`: `centerOfBounds` / `pointInBounds` を追加。
- `src/main.ts`: `deleteInverseOfSelected` の候補除外条件に「同 `sourceLayer` の選択 BBox 内に candidate の bbox 中心が入っているなら除外」を追加。タイル境界で 2 分割された選択 feature の partial が hidden 候補に紛れて「残したはずが消える」現象を防ぐ。

### D. 環境
- `vite.config.ts`: `server.host` を `127.0.0.1` に明示。Playwright `webServer.reuseExistingServer` が IPv4 で正しく動くように。

### E. テスト
- `tests/unit/zoomLock.test.ts`（新規, 4 件）: `lockZoom` / `unlockZoom` の snapshot 復元、`formatZoomDisplay`。
- `tests/unit/featureBounds.test.ts`: `centerOfBounds` / `pointInBounds` ブロック追加。
- `tests/e2e/display-and-export.spec.ts`: 編集 → ロック発動 → 編集リセット → ロック解除の 1 シナリオを追加。

### F. version
- `0.4.0` → `0.5.0`

## 受入条件

- [x] `hidden` / `highlighted` が空のままはズーム自由。
- [x] hide / highlight した瞬間に min/max が現行ズームで固定、`#zoom-display` に 🔒 表示。
- [x] 「編集をリセット」で min/max が元に戻り、🔒 が消える。
- [x] 「選択以外を削除」直後に空クリックで選択解除しても、選択していた feature 群が引き続き visible のまま（タイル境界 partial を保護）。
- [x] 既存 vitest / E2E がグリーン（unit 127 / e2e 15）。

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test`（127 件）
- [x] `pnpm e2e`（15 件）
- [x] `pnpm build`
- [x] 実ブラウザ: 削除 → `min/max=13`（ロック）→ リセット → `min/max=-2/22`（復元）、`#zoom-display` の表示・属性が連動

## スコープ外（別 issue）

- [#36](https://github.com/inuro/map-simplifier/issues/36): タイル跨ぎ feature 同一性の根本対応。本 PR の partial 除外はあくまで短期ガード。

🤖 Generated with [Claude Code](https://claude.com/claude-code)